### PR TITLE
Bug Fix : Install issues

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -14,6 +14,7 @@ whisper-server*
 whisper-server-package/
 *.db
 *.json
+*.bin
 
 
 ### Flask.Python Stack ###

--- a/backend/build_whisper.sh
+++ b/backend/build_whisper.sh
@@ -62,8 +62,21 @@ log_info "Verifying server files..."
 ls "examples/server/" || handle_error "Failed to list server files"
 
 log_section "Building Whisper Server"
-log_info "Running make with 4 threads..."
-make -j4 || handle_error "Build failed"
+log_info "Installing required dependencies..."
+brew install libomp llvm cmake || handle_error "Failed to install dependencies"
+
+log_info "Setting up compiler environment..."
+export CC=/opt/homebrew/opt/llvm/bin/clang
+export CXX=/opt/homebrew/opt/llvm/bin/clang++
+export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
+export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+
+log_info "Building whisper.cpp..."
+rm -rf build
+mkdir build && cd build || handle_error "Failed to create build directory"
+cmake -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ .. || handle_error "CMake configuration failed"
+make -j4 || handle_error "Make failed"
+cd ..
 log_success "Build completed successfully"
 
 # Configuration


### PR DESCRIPTION
# Fix Whisper.cpp Build Issues on macOS

## Problem
The build process was failing on macOS with a "vector file not found" error, indicating compiler configuration issues with the LLVM toolchain.

## Changes Made
1. Updated [build_whisper.sh](cci:7://file:///Users/sujith/work/2024/MVPs/meeting-minutes/backend/build_whisper.sh:0:0-0:0) to:
   - Add automatic installation of required dependencies (libomp, llvm, cmake)
   - Configure proper compiler environment variables
   - Set correct LLVM compiler paths for CMake
   - Improve build directory handling with proper cleanup
   - Add proper directory navigation after build

2. Updated [.gitignore](cci:7://file:///Users/sujith/work/2024/MVPs/meeting-minutes/backend/.gitignore:0:0-0:0) to:
   - Add `*.bin` to ignore list to prevent committing model files

## Technical Details
- Set compiler paths to use Homebrew's LLVM installation:
  ```bash
  CC=/opt/homebrew/opt/llvm/bin/clang
  CXX=/opt/homebrew/opt/llvm/bin/clang++