### PR TITLE
Fix UTF-8 string slicing panic in API response logging

### DIFF
--- a/frontend/src-tauri/src/api/api.rs
+++ b/frontend/src-tauri/src/api/api.rs
@@ -208,7 +208,8 @@ async fn get_auth_token<R: Runtime>(app: &AppHandle<R>) -> Option<String> {
     match store.get("authToken") {
         Some(token) => {
             if let Some(token_str) = token.as_str() {
-                log_info!("Found auth token: {}", &token_str[..std::cmp::min(20, token_str.len())]);
+                let truncated = token_str.chars().take(20).collect::<String>();
+                log_info!("Found auth token: {}", truncated);
                 Some(token_str.to_string())
             } else {
                 log_warn!("Auth token is not a string");
@@ -295,7 +296,12 @@ async fn make_api_request<R: Runtime, T: for<'de> Deserialize<'de>>(
         error_msg
     })?;
     
-    log_info!("Response body: {}", &response_text[..std::cmp::min(200, response_text.len())]);
+    // Safely truncate response for logging, respecting UTF-8 character boundaries
+    let truncated = response_text
+        .chars()
+        .take(200)
+        .collect::<String>();
+    log_info!("Response body: {}", truncated);
     
     serde_json::from_str(&response_text).map_err(|e| {
         let error_msg = format!("Failed to parse JSON: {}", e);


### PR DESCRIPTION
## Summary
- Fixed panic when logging API responses containing multi-byte UTF-8 characters
- Replaced unsafe byte-index string slicing with character-aware truncation
- Affects API response logging and auth token logging

## Problem
The application panicked when transcribing audio in non-Latin scripts (Punjabi/Gurmukhi in this case). The panic occurred in `api.rs` when attempting to log API responses:

```
thread panicked at src/api/api.rs:298:50:
byte index 200 is not a char boundary; it is inside 'ਮ' (bytes 198..201)
```

## Root Cause
Two locations used direct byte-index slicing on potentially multi-byte UTF-8 strings:
1. **Line 298**: Logging API response body truncated to 200 bytes
2. **Line 211**: Logging auth token truncated to 20 bytes

When these strings contained multi-byte UTF-8 characters, slicing at a fixed byte index could split a character, causing a panic.

## Solution
Replaced byte-index slicing with character-aware truncation:

**Before:**
```rust
&response_text[..std::cmp::min(200, response_text.len())]
```

**After:**
```rust
let truncated = response_text.chars().take(200).collect::<String>();
```

This approach:
- Safely truncates to 200 **characters** (not bytes)
- Respects UTF-8 character boundaries
- Works correctly with all Unicode scripts

## Test Plan
- [x] Test with Malayalam/Punjabi transcription (multi-byte UTF-8)
- [x] Verify no panic occurs when logging responses
- [x] Confirm truncation works correctly for both ASCII and multi-byte strings
- [x] Test auth token logging with various character sets

## Files Changed
- `frontend/src-tauri/src/api/api.rs` - Fixed two string slicing operations
