### PR TITLE
fix: sidebar animation text wrapping

### DIFF
--- a/frontend/src/components/Sidebar/index.tsx
+++ b/frontend/src/components/Sidebar/index.tsx
@@ -705,7 +705,7 @@ const Sidebar: React.FC = () => {
             {!isCollapsed && (
               <div
                 onClick={() => router.push('/')}
-                className="p-3  text-lg font-semibold items-center hover:bg-gray-100 h-10   flex mx-3 mt-3 rounded-lg cursor-pointer"
+                className="p-3  text-lg font-semibold items-center hover:bg-gray-100 h-10   flex mx-3 mt-3 rounded-lg cursor-pointer  min-w-48"
               >
                 <Home className="w-4 h-4 mr-2" />
                 <span>Home</span>
@@ -722,7 +722,7 @@ const Sidebar: React.FC = () => {
                 {filteredSidebarItems.filter(item => item.type === 'folder').map(item => (
                   <div key={item.id}>
                     <div
-                      className="flex items-center transition-all duration-150 p-3 text-lg font-semibold h-10 mx-3 mt-3 rounded-lg"
+                      className="flex items-center transition-all duration-150 p-3 text-lg font-semibold h-10 mx-3 mt-3 rounded-lg min-w-64"
                     >
                       <NotebookPen className="w-4 h-4 mr-2 text-gray-600" />
                       <span className="text-gray-700">{item.title}</span>
@@ -737,7 +737,7 @@ const Sidebar: React.FC = () => {
 
             {/* Scrollable meeting items */}
             {!isCollapsed && (
-              <div className="flex-1 overflow-y-auto custom-scrollbar min-h-0">
+              <div className="flex-1 overflow-y-auto custom-scrollbar min-h-0 min-w-64">
                 {filteredSidebarItems
                   .filter(item => item.type === 'folder' && expandedFolders.has(item.id) && item.children)
                   .map(item => (


### PR DESCRIPTION
## Description
CSS-only update that fixes the sidebar animation

## Related Issue
Fixes #244 

## Type of Change
- [x] Bug fix

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] All tests pass

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [ ] Added comments for complex code
- [ ] Updated README if needed
- [ ] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)

After:
https://github.com/user-attachments/assets/05e86f93-97dd-4e58-b3a0-0ba5aa280747


## Additional Notes
The "Home" item needed a smaller min-width than the others, because it has a mouse-over effect that enables the background color.