### PR TITLE
added timestamp to the summary generation prompt

### DIFF
--- a/frontend/src/hooks/meeting-details/useSummaryGeneration.ts
+++ b/frontend/src/hooks/meeting-details/useSummaryGeneration.ts
@@ -416,7 +416,22 @@ export function useSummaryGeneration({
       }
     }
 
-    const fullTranscript = transcripts.map(t => t.text).join('\n');
+    // Format timestamps as recording-relative [MM:SS] instead of wall-clock time
+    const formatTime = (seconds: number | undefined, fallbackTimestamp: string): string => {
+      if (seconds === undefined) {
+        // For old transcripts without audio_start_time, use wall-clock time
+        return fallbackTimestamp;
+      }
+      const totalSecs = Math.floor(seconds);
+      const mins = Math.floor(totalSecs / 60);
+      const secs = totalSecs % 60;
+      return `[${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}]`;
+    };
+
+    const fullTranscript = transcripts
+      .map(t => `${formatTime(t.audio_start_time, t.timestamp)} ${t.text}`)
+      .join('\n');
+
     await processSummary({ transcriptText: fullTranscript, customPrompt });
   }, [transcripts, processSummary, modelConfig, isModelConfigLoading, selectedTemplate]);
 


### PR DESCRIPTION
## Description
the transcript shared for summary generation to the backend was missing the timestamps,

the fix added the timestamps like the copy of transcript

## Related Issue
[Link to the issue this PR addresses (e.g., "Fixes #123")]

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass

## Documentation
- [ ] Documentation updated
- [ ] No documentation needed

## Checklist
- [ ] Code follows project style
- [ ] Self-reviewed the code
- [ ] Added comments for complex code
- [ ] Updated README if needed
- [ ] Branch is up to date with devtest
- [ ] No merge conflicts

## Screenshots (if applicable)
[Add screenshots here if your changes affect the UI]

## Additional Notes
[Add any additional information that might be helpful for reviewers] 