### PR TITLE
docs(linux): add cd and npm install

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -32,6 +32,9 @@ sudo pacman -S base-devel cmake git
 #### 2. Build and Run
 
 ```bash
+cd frontend
+npm install
+
 # Development mode (with hot reload)
 ./dev-gpu.sh
 

--- a/docs/building_in_linux.md
+++ b/docs/building_in_linux.md
@@ -25,6 +25,9 @@ sudo pacman -S base-devel cmake git
 ### 2. Build and Run
 
 ```bash
+cd frontend
+npm install
+
 # Development mode (with hot reload)
 ./dev-gpu.sh
 


### PR DESCRIPTION
## Description
Modifies the Linux build docs to mention that the commands need to be run from the `frontend/` dir, as well as having to run `npm install` before building.

## Related Issue
Resolves https://github.com/Zackriya-Solutions/meeting-minutes/issues/240

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [X] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass

## Documentation
- [ ] Documentation updated
- [ ] No documentation needed

## Checklist
- [ ] Code follows project style
- [ ] Self-reviewed the code
- [ ] Added comments for complex code
- [ ] Updated README if needed
- [ ] Branch is up to date with devtest
- [ ] No merge conflicts
