### PR TITLE
feat: add retranscription feature for re-processing meeting audio

### DIFF
--- a/frontend/src-tauri/migrations/20260113000000_add_transcription_language.sql
+++ b/frontend/src-tauri/migrations/20260113000000_add_transcription_language.sql
@@ -1,0 +1,3 @@
+-- Add transcription_language column to meetings table
+-- This stores the language used for transcription (null = auto-detected)
+ALTER TABLE meetings ADD COLUMN transcription_language TEXT;

--- a/frontend/src-tauri/src/audio/decoder.rs
+++ b/frontend/src-tauri/src/audio/decoder.rs
@@ -1,0 +1,507 @@
+// Audio file decoder for retranscription feature
+// Uses Symphonia to decode MP4/AAC audio files
+
+use anyhow::{anyhow, Result};
+use log::{debug, info, warn};
+use std::path::Path;
+
+use symphonia::core::audio::SampleBuffer;
+use symphonia::core::codecs::{DecoderOptions, CODEC_TYPE_NULL};
+use symphonia::core::formats::FormatOptions;
+use symphonia::core::io::MediaSourceStream;
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+
+use super::audio_processing::{audio_to_mono, resample_audio};
+
+/// Decoded audio data from a file
+#[derive(Debug, Clone)]
+pub struct DecodedAudio {
+    /// Raw audio samples (interleaved if stereo)
+    pub samples: Vec<f32>,
+    /// Sample rate of the decoded audio
+    pub sample_rate: u32,
+    /// Number of channels (1 = mono, 2 = stereo)
+    pub channels: u16,
+    /// Duration in seconds
+    pub duration_seconds: f64,
+}
+
+impl DecodedAudio {
+    /// Convert decoded audio to Whisper-compatible format (16kHz mono f32)
+    pub fn to_whisper_format(&self) -> Vec<f32> {
+        // Step 1: Convert to mono if needed
+        let mono_samples = if self.channels > 1 {
+            info!(
+                "Converting {} channels to mono ({} samples)",
+                self.channels,
+                self.samples.len()
+            );
+            audio_to_mono(&self.samples, self.channels)
+        } else {
+            self.samples.clone()
+        };
+
+        // Step 1.5: Normalize samples to valid range (-1.0 to 1.0)
+        // Some audio files may have samples slightly outside this range
+        let mono_samples = normalize_audio_samples(mono_samples);
+
+        // Step 2: Resample to 16kHz if needed
+        const WHISPER_SAMPLE_RATE: u32 = 16000;
+        if self.sample_rate != WHISPER_SAMPLE_RATE {
+            // Use fast linear resampling for large files (>5 minutes at 48kHz = 14.4M samples)
+            // The high-quality sinc resampler is too slow for retranscription of long recordings
+            const LARGE_FILE_THRESHOLD: usize = 14_400_000;
+
+            if mono_samples.len() > LARGE_FILE_THRESHOLD {
+                info!(
+                    "Fast resampling {} samples from {}Hz to {}Hz (large file mode)",
+                    mono_samples.len(),
+                    self.sample_rate,
+                    WHISPER_SAMPLE_RATE
+                );
+                fast_resample(&mono_samples, self.sample_rate, WHISPER_SAMPLE_RATE)
+            } else {
+                info!(
+                    "Resampling {} samples from {}Hz to {}Hz",
+                    mono_samples.len(),
+                    self.sample_rate,
+                    WHISPER_SAMPLE_RATE
+                );
+                resample_audio(&mono_samples, self.sample_rate, WHISPER_SAMPLE_RATE)
+            }
+        } else {
+            mono_samples
+        }
+    }
+}
+
+/// Fast linear interpolation resampling for large files
+/// Much faster than sinc resampling, good enough quality for speech transcription
+fn fast_resample(input: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
+    if input.is_empty() || from_rate == to_rate {
+        return input.to_vec();
+    }
+
+    let ratio = from_rate as f64 / to_rate as f64;
+    let output_len = (input.len() as f64 / ratio) as usize;
+    let mut output = Vec::with_capacity(output_len);
+
+    // Log progress for very large files
+    let log_interval = output_len / 10; // Log every 10%
+
+    for i in 0..output_len {
+        let src_pos = i as f64 * ratio;
+        let src_idx = src_pos as usize;
+        let frac = (src_pos - src_idx as f64) as f32;
+
+        let sample = if src_idx + 1 < input.len() {
+            // Linear interpolation
+            input[src_idx] * (1.0 - frac) + input[src_idx + 1] * frac
+        } else if src_idx < input.len() {
+            input[src_idx]
+        } else {
+            0.0
+        };
+        output.push(sample);
+
+        // Log progress every 10%
+        if log_interval > 0 && i > 0 && i % log_interval == 0 {
+            debug!("Resampling progress: {}%", (i * 100) / output_len);
+        }
+    }
+
+    debug!("Fast resampling complete: {} -> {} samples", input.len(), output.len());
+    output
+}
+
+/// Normalize audio samples to the valid range (-1.0 to 1.0)
+/// This handles audio files that may have samples slightly outside the expected range
+fn normalize_audio_samples(mut samples: Vec<f32>) -> Vec<f32> {
+    // First, find the maximum absolute value
+    let max_abs = samples
+        .iter()
+        .map(|s| s.abs())
+        .fold(0.0f32, |a, b| a.max(b));
+
+    if max_abs > 1.0 {
+        // Audio exceeds valid range - normalize by scaling
+        info!(
+            "Audio samples exceed valid range (max: {:.3}), normalizing...",
+            max_abs
+        );
+        let scale = 1.0 / max_abs;
+        for sample in &mut samples {
+            *sample *= scale;
+        }
+    }
+
+    // Also clamp any remaining edge cases (NaN, infinity, etc.)
+    for sample in &mut samples {
+        if !sample.is_finite() {
+            *sample = 0.0;
+        } else {
+            *sample = sample.clamp(-1.0, 1.0);
+        }
+    }
+
+    samples
+}
+
+/// Decode an audio file (MP4, M4A, WAV, etc.) to raw samples
+pub fn decode_audio_file(path: &Path) -> Result<DecodedAudio> {
+    info!("Decoding audio file: {}", path.display());
+
+    // Open the file
+    let file = std::fs::File::open(path)
+        .map_err(|e| anyhow!("Failed to open audio file '{}': {}", path.display(), e))?;
+
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+
+    // Set up format hint based on file extension
+    let mut hint = Hint::new();
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        hint.with_extension(ext);
+    }
+
+    // Probe the file format
+    let probed = symphonia::default::get_probe()
+        .format(
+            &hint,
+            mss,
+            &FormatOptions::default(),
+            &MetadataOptions::default(),
+        )
+        .map_err(|e| anyhow!("Failed to probe audio format: {}", e))?;
+
+    let mut format = probed.format;
+
+    // Find the first audio track
+    let track = format
+        .tracks()
+        .iter()
+        .find(|t| t.codec_params.codec != CODEC_TYPE_NULL)
+        .ok_or_else(|| anyhow!("No audio track found in file"))?;
+
+    let track_id = track.id;
+
+    // Get audio parameters
+    let sample_rate = track
+        .codec_params
+        .sample_rate
+        .ok_or_else(|| anyhow!("Unknown sample rate"))?;
+
+    let channels = track
+        .codec_params
+        .channels
+        .map(|c| c.count() as u16)
+        .unwrap_or(1);
+
+    debug!(
+        "Audio track: {}Hz, {} channels",
+        sample_rate, channels
+    );
+
+    // Create the decoder
+    let mut decoder = symphonia::default::get_codecs()
+        .make(&track.codec_params, &DecoderOptions::default())
+        .map_err(|e| anyhow!("Failed to create decoder: {}", e))?;
+
+    // Decode all packets
+    let mut all_samples: Vec<f32> = Vec::new();
+    let mut sample_buf: Option<SampleBuffer<f32>> = None;
+
+    loop {
+        // Get the next packet
+        let packet = match format.next_packet() {
+            Ok(packet) => packet,
+            Err(symphonia::core::errors::Error::IoError(ref e))
+                if e.kind() == std::io::ErrorKind::UnexpectedEof =>
+            {
+                // End of file
+                break;
+            }
+            Err(e) => {
+                warn!("Error reading packet: {}", e);
+                break;
+            }
+        };
+
+        // Skip packets from other tracks
+        if packet.track_id() != track_id {
+            continue;
+        }
+
+        // Decode the packet
+        match decoder.decode(&packet) {
+            Ok(decoded) => {
+                // Initialize sample buffer if needed
+                if sample_buf.is_none() {
+                    let spec = *decoded.spec();
+                    let duration = decoded.capacity() as u64;
+                    sample_buf = Some(SampleBuffer::<f32>::new(duration, spec));
+                }
+
+                // Copy samples to buffer
+                if let Some(ref mut buf) = sample_buf {
+                    buf.copy_interleaved_ref(decoded);
+                    all_samples.extend_from_slice(buf.samples());
+                }
+            }
+            Err(e) => {
+                warn!("Error decoding packet: {}", e);
+                continue;
+            }
+        }
+    }
+
+    if all_samples.is_empty() {
+        return Err(anyhow!("No audio samples decoded from file"));
+    }
+
+    let total_frames = all_samples.len() / channels as usize;
+    let duration_seconds = total_frames as f64 / sample_rate as f64;
+
+    info!(
+        "Decoded {} samples ({:.2}s) at {}Hz, {} channels",
+        all_samples.len(),
+        duration_seconds,
+        sample_rate,
+        channels
+    );
+
+    Ok(DecodedAudio {
+        samples: all_samples,
+        sample_rate,
+        channels,
+        duration_seconds,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_whisper_format_mono_16k() {
+        // Already in correct format
+        let audio = DecodedAudio {
+            samples: vec![0.1, 0.2, 0.3],
+            sample_rate: 16000,
+            channels: 1,
+            duration_seconds: 0.0001875,
+        };
+
+        let result = audio.to_whisper_format();
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_to_whisper_format_stereo_to_mono() {
+        // Stereo input
+        let audio = DecodedAudio {
+            samples: vec![0.2, 0.4, 0.6, 0.8], // 2 stereo frames
+            sample_rate: 16000,
+            channels: 2,
+            duration_seconds: 0.000125,
+        };
+
+        let result = audio.to_whisper_format();
+        assert_eq!(result.len(), 2); // Should be mono now
+        // Average of (0.2, 0.4) = 0.3 and (0.6, 0.8) = 0.7
+        assert!((result[0] - 0.3).abs() < 0.001);
+        assert!((result[1] - 0.7).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_to_whisper_format_resamples_48k_to_16k() {
+        // 48kHz mono input - should be downsampled to 16kHz
+        // Use a larger sample to ensure resampler works correctly
+        // 48000 samples at 48kHz = 1 second → 16000 samples at 16kHz
+        let audio = DecodedAudio {
+            samples: vec![0.5; 4800], // 0.1 seconds at 48kHz
+            sample_rate: 48000,
+            channels: 1,
+            duration_seconds: 4800.0 / 48000.0,
+        };
+
+        let result = audio.to_whisper_format();
+        // Output length should be approximately input_len / 3 (16000/48000 ratio)
+        // 4800 / 3 = 1600
+        assert!(!result.is_empty(), "Result should not be empty");
+        assert!(result.len() > 1000 && result.len() < 2000,
+            "Expected ~1600 samples, got {}", result.len());
+    }
+
+    #[test]
+    fn test_fast_resample_same_rate() {
+        // Same rate should return identical samples
+        let input = vec![0.1, 0.2, 0.3, 0.4, 0.5];
+        let result = fast_resample(&input, 16000, 16000);
+        assert_eq!(result.len(), input.len());
+        for (i, &sample) in result.iter().enumerate() {
+            assert!((sample - input[i]).abs() < 0.001);
+        }
+    }
+
+    #[test]
+    fn test_fast_resample_empty_input() {
+        let input: Vec<f32> = vec![];
+        let result = fast_resample(&input, 48000, 16000);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_fast_resample_downsamples_correctly() {
+        // 48kHz to 16kHz = 3x downsampling
+        // Create a simple ramp signal
+        let input: Vec<f32> = (0..30).map(|i| i as f32 / 30.0).collect();
+        let result = fast_resample(&input, 48000, 16000);
+
+        // Output should be approximately 1/3 the length
+        assert_eq!(result.len(), 10);
+
+        // First sample should be close to 0
+        assert!(result[0].abs() < 0.1);
+
+        // Last sample should be close to the end of the ramp
+        assert!(result[9] > 0.8);
+    }
+
+    #[test]
+    fn test_fast_resample_upsamples_correctly() {
+        // 16kHz to 48kHz = 3x upsampling
+        let input: Vec<f32> = vec![0.0, 0.5, 1.0];
+        let result = fast_resample(&input, 16000, 48000);
+
+        // Output should be approximately 3x the length
+        assert_eq!(result.len(), 9);
+
+        // Should interpolate smoothly between values
+        // ratio = 16000/48000 = 0.333...
+        // For i=0: src_pos=0.0 → 0.0
+        // For i=3: src_pos=1.0 → 0.5 (at input[1])
+        // For i=6: src_pos=2.0 → 1.0 (at input[2])
+        assert!(result[0].abs() < 0.01, "First sample should be ~0.0, got {}", result[0]);
+        assert!((result[3] - 0.5).abs() < 0.01, "Sample at index 3 should be ~0.5, got {}", result[3]);
+        assert!((result[6] - 1.0).abs() < 0.01, "Sample at index 6 should be ~1.0, got {}", result[6]);
+
+        // Values should be monotonically increasing for this input
+        for i in 1..result.len() {
+            assert!(result[i] >= result[i-1] - 0.001,
+                "Should be monotonic: result[{}]={} < result[{}]={}",
+                i, result[i], i-1, result[i-1]);
+        }
+    }
+
+    #[test]
+    fn test_fast_resample_preserves_signal_range() {
+        // Ensure resampling doesn't create values outside input range
+        let input: Vec<f32> = (0..1000).map(|i| (i as f32 * 0.001).sin()).collect();
+        let result = fast_resample(&input, 44100, 16000);
+
+        for sample in &result {
+            assert!(*sample >= -1.0 && *sample <= 1.0,
+                "Sample {} out of range [-1, 1]", sample);
+        }
+    }
+
+    #[test]
+    fn test_fast_resample_linear_interpolation_accuracy() {
+        // Test that linear interpolation works correctly
+        // Input: 0.0 at index 0, 1.0 at index 1
+        // With 2x upsampling, we expect: 0.0, 0.5, 1.0
+        let input: Vec<f32> = vec![0.0, 1.0];
+        let result = fast_resample(&input, 16000, 32000);
+
+        assert_eq!(result.len(), 4);
+        assert!((result[0] - 0.0).abs() < 0.01); // First sample
+        assert!((result[1] - 0.5).abs() < 0.01); // Interpolated
+        assert!((result[2] - 1.0).abs() < 0.01); // At index 1
+    }
+
+    #[test]
+    fn test_decoded_audio_duration_calculation() {
+        let audio = DecodedAudio {
+            samples: vec![0.0; 48000], // 1 second at 48kHz mono
+            sample_rate: 48000,
+            channels: 1,
+            duration_seconds: 1.0,
+        };
+
+        // Duration should be samples / sample_rate for mono
+        let calculated_duration = audio.samples.len() as f64 / audio.sample_rate as f64;
+        assert!((calculated_duration - audio.duration_seconds).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_decoded_audio_stereo_duration() {
+        let audio = DecodedAudio {
+            samples: vec![0.0; 96000], // 1 second at 48kHz stereo (2 channels)
+            sample_rate: 48000,
+            channels: 2,
+            duration_seconds: 1.0,
+        };
+
+        // Duration should be samples / (sample_rate * channels) for stereo
+        let frames = audio.samples.len() / audio.channels as usize;
+        let calculated_duration = frames as f64 / audio.sample_rate as f64;
+        assert!((calculated_duration - audio.duration_seconds).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_to_whisper_format_handles_large_file_threshold() {
+        // Test that large files use fast resampling path
+        // LARGE_FILE_THRESHOLD is 14_400_000 samples
+        // We'll test with a smaller sample to verify the path selection logic works
+        let audio = DecodedAudio {
+            samples: vec![0.5; 1000], // Small file
+            sample_rate: 48000,
+            channels: 1,
+            duration_seconds: 1000.0 / 48000.0,
+        };
+
+        let result = audio.to_whisper_format();
+        // Should complete without error and produce valid output
+        assert!(!result.is_empty());
+        assert!(result.len() < 1000); // Downsampled
+    }
+
+    #[test]
+    fn test_normalize_audio_samples_already_normalized() {
+        let samples = vec![0.5, -0.5, 0.0, 0.9, -0.9];
+        let result = normalize_audio_samples(samples.clone());
+        // Should be unchanged (already in range)
+        for (i, &s) in result.iter().enumerate() {
+            assert!((s - samples[i]).abs() < 0.001);
+        }
+    }
+
+    #[test]
+    fn test_normalize_audio_samples_exceeds_range() {
+        let samples = vec![0.5, -0.5, 2.0, -1.5]; // max_abs = 2.0
+        let result = normalize_audio_samples(samples);
+        // All samples should be scaled by 0.5 (1.0 / 2.0)
+        assert!((result[0] - 0.25).abs() < 0.001);
+        assert!((result[1] - -0.25).abs() < 0.001);
+        assert!((result[2] - 1.0).abs() < 0.001);
+        assert!((result[3] - -0.75).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_normalize_audio_samples_handles_nan() {
+        let samples = vec![0.5, f32::NAN, 0.3];
+        let result = normalize_audio_samples(samples);
+        assert!((result[0] - 0.5).abs() < 0.001);
+        assert_eq!(result[1], 0.0); // NaN replaced with 0
+        assert!((result[2] - 0.3).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_normalize_audio_samples_handles_infinity() {
+        let samples = vec![0.5, f32::INFINITY, -0.3];
+        let result = normalize_audio_samples(samples);
+        // Infinity will be clamped to 0.0 (since !is_finite)
+        assert_eq!(result[1], 0.0);
+    }
+}

--- a/frontend/src-tauri/src/audio/incremental_saver.rs
+++ b/frontend/src-tauri/src/audio/incremental_saver.rs
@@ -433,10 +433,12 @@ mod tests {
         ).unwrap();
 
         // Add 60 seconds worth of audio (should create 2 checkpoints)
-        for _ in 0..120 {  // 120 chunks of 0.5s each
+        for i in 0..120 {  // 120 chunks of 0.5s each
             let chunk = AudioChunk {
                 data: vec![0.5f32; 24000],  // 0.5s at 48kHz
                 sample_rate: 48000,
+                timestamp: i as f64 * 0.5,  // timestamp in seconds
+                chunk_id: i as u64,
                 device_type: DeviceType::Microphone,
             };
             saver.add_chunk(chunk).unwrap();

--- a/frontend/src-tauri/src/audio/mod.rs
+++ b/frontend/src-tauri/src/audio/mod.rs
@@ -1,5 +1,6 @@
 // src/audio/mod.rs
 pub mod audio_processing;
+pub mod decoder;
 pub mod encode;
 pub mod ffmpeg;
 pub mod vad;
@@ -37,6 +38,9 @@ pub mod playback_monitor; // NEW: Playback device detection for BT warnings
 
 // Transcription module (provider abstraction, engine management, worker pool)
 pub mod transcription;
+
+// Retranscription module (re-process stored audio with different settings)
+pub mod retranscription;
 
 pub use devices::{
     default_input_device, default_output_device, get_device_and_config, list_audio_devices,
@@ -99,4 +103,7 @@ pub use diagnostics::{
 pub use ffmpeg_mixer::{FFmpegAudioMixer, BufferStats, RNNOISE_APPLY_ENABLED};
 
 pub use vad::{extract_speech_16k};
+
+// Export decoder for retranscription
+pub use decoder::{decode_audio_file, DecodedAudio};
 

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -1,0 +1,853 @@
+// Retranscription module - allows re-processing stored audio with different settings
+
+use crate::api::TranscriptSegment;
+use crate::audio::decoder::decode_audio_file;
+use crate::audio::vad::get_speech_chunks_with_progress;
+use crate::parakeet_engine::ParakeetEngine;
+use crate::state::AppState;
+use crate::whisper_engine::WhisperEngine;
+use anyhow::{anyhow, Result};
+use log::{debug, error, info, warn};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tauri::{AppHandle, Emitter, Manager, Runtime};
+use uuid::Uuid;
+
+/// Global flag to track if retranscription is in progress
+static RETRANSCRIPTION_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+/// Global flag to signal cancellation
+static RETRANSCRIPTION_CANCELLED: AtomicBool = AtomicBool::new(false);
+
+/// VAD redemption time in milliseconds - bridges natural pauses in speech
+/// 400ms matches live transcription settings (pipeline.rs:727)
+const VAD_REDEMPTION_TIME_MS: u32 = 400;
+
+/// Progress update emitted during retranscription
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetranscriptionProgress {
+    pub meeting_id: String,
+    pub stage: String, // "decoding", "transcribing", "saving"
+    pub progress_percentage: u32,
+    pub message: String,
+}
+
+/// Result of retranscription
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetranscriptionResult {
+    pub meeting_id: String,
+    pub segments_count: usize,
+    pub duration_seconds: f64,
+    pub language: Option<String>,
+}
+
+/// Error during retranscription
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetranscriptionError {
+    pub meeting_id: String,
+    pub error: String,
+}
+
+/// Check if retranscription is currently in progress
+pub fn is_retranscription_in_progress() -> bool {
+    RETRANSCRIPTION_IN_PROGRESS.load(Ordering::SeqCst)
+}
+
+/// Cancel ongoing retranscription
+pub fn cancel_retranscription() {
+    RETRANSCRIPTION_CANCELLED.store(true, Ordering::SeqCst);
+}
+
+/// Start retranscription of a meeting's audio
+pub async fn start_retranscription<R: Runtime>(
+    app: AppHandle<R>,
+    meeting_id: String,
+    meeting_folder_path: String,
+    language: Option<String>,
+    model: Option<String>,
+    provider: Option<String>,
+) -> Result<RetranscriptionResult> {
+    // Check if already in progress
+    if RETRANSCRIPTION_IN_PROGRESS.swap(true, Ordering::SeqCst) {
+        return Err(anyhow!("Retranscription already in progress"));
+    }
+
+    // Reset cancellation flag
+    RETRANSCRIPTION_CANCELLED.store(false, Ordering::SeqCst);
+
+    let result = run_retranscription(app.clone(), meeting_id.clone(), meeting_folder_path, language, model, provider).await;
+
+    // Clear in-progress flag
+    RETRANSCRIPTION_IN_PROGRESS.store(false, Ordering::SeqCst);
+
+    match &result {
+        Ok(res) => {
+            let _ = app.emit(
+                "retranscription-complete",
+                serde_json::json!({
+                    "meeting_id": res.meeting_id,
+                    "segments_count": res.segments_count,
+                    "duration_seconds": res.duration_seconds,
+                    "language": res.language
+                }),
+            );
+        }
+        Err(e) => {
+            let _ = app.emit(
+                "retranscription-error",
+                RetranscriptionError {
+                    meeting_id: meeting_id.clone(),
+                    error: e.to_string(),
+                },
+            );
+        }
+    }
+
+    result
+}
+
+/// Internal function to run retranscription
+async fn run_retranscription<R: Runtime>(
+    app: AppHandle<R>,
+    meeting_id: String,
+    meeting_folder_path: String,
+    language: Option<String>,
+    model: Option<String>,
+    provider: Option<String>,
+) -> Result<RetranscriptionResult> {
+    let folder_path = PathBuf::from(&meeting_folder_path);
+    let audio_path = folder_path.join("audio.mp4");
+
+    // Check if audio file exists
+    if !audio_path.exists() {
+        return Err(anyhow!(
+            "Audio file not found: {}",
+            audio_path.display()
+        ));
+    }
+
+    // Determine which provider to use (default to whisper)
+    let use_parakeet = provider.as_deref() == Some("parakeet");
+
+    info!(
+        "Starting retranscription for meeting {} with language {:?}, model {:?}, provider {:?}",
+        meeting_id, language, model, provider
+    );
+
+    // Emit progress: decoding
+    emit_progress(&app, &meeting_id, "decoding", 5, "Decoding audio file...");
+
+    // Check for cancellation
+    if RETRANSCRIPTION_CANCELLED.load(Ordering::SeqCst) {
+        return Err(anyhow!("Retranscription cancelled"));
+    }
+
+    // Decode the audio file
+    let decoded = decode_audio_file(&audio_path)?;
+    let duration_seconds = decoded.duration_seconds;
+
+    info!(
+        "Decoded audio: {:.2}s, {}Hz, {} channels",
+        duration_seconds, decoded.sample_rate, decoded.channels
+    );
+
+    emit_progress(&app, &meeting_id, "decoding", 15, "Converting audio format...");
+
+    // Check for cancellation
+    if RETRANSCRIPTION_CANCELLED.load(Ordering::SeqCst) {
+        return Err(anyhow!("Retranscription cancelled"));
+    }
+
+    // Convert to 16kHz mono format (used by both Whisper, Parakeet, and VAD)
+    let audio_samples = decoded.to_whisper_format();
+    info!("Converted to 16kHz mono format: {} samples", audio_samples.len());
+
+    emit_progress(&app, &meeting_id, "vad", 20, "Detecting speech segments...");
+
+    // Check for cancellation
+    if RETRANSCRIPTION_CANCELLED.load(Ordering::SeqCst) {
+        return Err(anyhow!("Retranscription cancelled"));
+    }
+
+    // Use VAD to find natural speech boundaries (same approach as live transcription)
+    // IMPORTANT: Run VAD in a blocking task to avoid blocking the async runtime
+    // For large files (35+ minutes), VAD processing can take several minutes
+    let app_for_vad = app.clone();
+    let meeting_id_for_vad = meeting_id.clone();
+
+    let speech_segments = tokio::task::spawn_blocking(move || {
+        get_speech_chunks_with_progress(
+            &audio_samples,
+            VAD_REDEMPTION_TIME_MS,
+            |vad_progress, segments_found| {
+                // Map VAD progress (0-100) to overall progress (20-25)
+                let overall_progress = 20 + (vad_progress as f32 * 0.05) as u32;
+                emit_progress(
+                    &app_for_vad,
+                    &meeting_id_for_vad,
+                    "vad",
+                    overall_progress,
+                    &format!("Detecting speech segments... {}% ({} found)", vad_progress, segments_found),
+                );
+
+                // Return false to cancel if cancellation requested
+                !RETRANSCRIPTION_CANCELLED.load(Ordering::SeqCst)
+            },
+        )
+    })
+    .await
+    .map_err(|e| anyhow!("VAD task panicked: {}", e))?
+    .map_err(|e| anyhow!("VAD processing failed: {}", e))?;
+
+    let total_segments = speech_segments.len();
+    info!("VAD detected {} speech segments", total_segments);
+
+    if total_segments == 0 {
+        warn!("No speech detected in audio");
+        return Err(anyhow!("No speech detected in audio file"));
+    }
+
+    emit_progress(&app, &meeting_id, "transcribing", 25, "Loading transcription engine...");
+
+    // Initialize the appropriate engine once (not per-segment)
+    let whisper_engine = if !use_parakeet {
+        Some(get_or_init_whisper(&app, model.as_deref()).await?)
+    } else {
+        None
+    };
+    let parakeet_engine = if use_parakeet {
+        Some(get_or_init_parakeet(&app, model.as_deref()).await?)
+    } else {
+        None
+    };
+
+    // Split very long segments to avoid transcription engine limits
+    // Most engines have ~30 second limits, so we split at 25 seconds to be safe
+    const MAX_SEGMENT_DURATION_MS: f64 = 25_000.0; // 25 seconds
+    const MAX_SEGMENT_SAMPLES: usize = 25 * 16000; // 25 seconds at 16kHz
+
+    let mut processable_segments: Vec<crate::audio::vad::SpeechSegment> = Vec::new();
+    for segment in &speech_segments {
+        let segment_duration_ms = segment.end_timestamp_ms - segment.start_timestamp_ms;
+        if segment_duration_ms > MAX_SEGMENT_DURATION_MS || segment.samples.len() > MAX_SEGMENT_SAMPLES {
+            // Split into smaller chunks
+            debug!("Splitting large segment ({}ms, {} samples) into smaller chunks",
+                  segment_duration_ms, segment.samples.len());
+
+            let num_chunks = (segment.samples.len() + MAX_SEGMENT_SAMPLES - 1) / MAX_SEGMENT_SAMPLES;
+            let samples_per_chunk = segment.samples.len() / num_chunks;
+            let ms_per_sample = segment_duration_ms / segment.samples.len() as f64;
+
+            for chunk_idx in 0..num_chunks {
+                let start_idx = chunk_idx * samples_per_chunk;
+                let end_idx = if chunk_idx == num_chunks - 1 {
+                    segment.samples.len()
+                } else {
+                    (chunk_idx + 1) * samples_per_chunk
+                };
+
+                let chunk_samples = segment.samples[start_idx..end_idx].to_vec();
+                let chunk_start_ms = segment.start_timestamp_ms + (start_idx as f64 * ms_per_sample);
+                let chunk_end_ms = segment.start_timestamp_ms + (end_idx as f64 * ms_per_sample);
+
+                processable_segments.push(crate::audio::vad::SpeechSegment {
+                    samples: chunk_samples,
+                    start_timestamp_ms: chunk_start_ms,
+                    end_timestamp_ms: chunk_end_ms,
+                    confidence: segment.confidence,
+                });
+            }
+            debug!("Split into {} chunks", num_chunks);
+        } else {
+            processable_segments.push(segment.clone());
+        }
+    }
+
+    let processable_count = processable_segments.len();
+    info!("Processing {} segments (after splitting)", processable_count);
+
+    // Process each speech segment with progress updates
+    let mut all_transcripts: Vec<(String, f64, f64)> = Vec::new(); // (text, start_ms, end_ms)
+    let mut total_confidence = 0.0f32;
+
+    for (i, segment) in processable_segments.iter().enumerate() {
+        // Check for cancellation before each segment
+        if RETRANSCRIPTION_CANCELLED.load(Ordering::SeqCst) {
+            return Err(anyhow!("Retranscription cancelled"));
+        }
+
+        // Calculate progress (25% to 80% range for transcription)
+        let progress = 25 + ((i as f32 / processable_count as f32) * 55.0) as u32;
+        let segment_duration_sec = (segment.end_timestamp_ms - segment.start_timestamp_ms) / 1000.0;
+        emit_progress(
+            &app,
+            &meeting_id,
+            "transcribing",
+            progress,
+            &format!(
+                "Transcribing segment {} of {} ({:.1}s)...",
+                i + 1,
+                processable_count,
+                segment_duration_sec
+            ),
+        );
+
+        // Skip very short segments (< 100ms of audio = 1600 samples at 16kHz)
+        if segment.samples.len() < 1600 {
+            debug!("Skipping short segment {} with {} samples", i, segment.samples.len());
+            continue;
+        }
+
+        // Transcribe this segment
+        let (text, conf) = if use_parakeet {
+            let engine = parakeet_engine.as_ref().unwrap();
+            let text = engine
+                .transcribe_audio(segment.samples.clone())
+                .await
+                .map_err(|e| anyhow!("Parakeet transcription failed on segment {}: {}", i, e))?;
+            (text, 0.9f32)
+        } else {
+            let engine = whisper_engine.as_ref().unwrap();
+            let (text, conf, _) = engine
+                .transcribe_audio_with_confidence(segment.samples.clone(), language.clone())
+                .await
+                .map_err(|e| anyhow!("Whisper transcription failed on segment {}: {}", i, e))?;
+            (text, conf)
+        };
+
+        // Skip empty transcripts
+        if !text.trim().is_empty() {
+            all_transcripts.push((text, segment.start_timestamp_ms, segment.end_timestamp_ms));
+            total_confidence += conf;
+        }
+    }
+
+    let transcribed_count = all_transcripts.len();
+    let avg_confidence = if transcribed_count > 0 {
+        total_confidence / transcribed_count as f32
+    } else {
+        0.0
+    };
+
+    info!(
+        "Transcription complete: {} segments transcribed, avg confidence: {:.2}",
+        transcribed_count, avg_confidence
+    );
+
+    // Check for cancellation
+    if RETRANSCRIPTION_CANCELLED.load(Ordering::SeqCst) {
+        return Err(anyhow!("Retranscription cancelled"));
+    }
+
+    emit_progress(&app, &meeting_id, "saving", 80, "Saving transcripts...");
+
+    // Create transcript segments with proper timestamps from VAD
+    let segments = create_transcript_segments_from_vad(&all_transcripts, avg_confidence);
+
+    // Save to database
+    let app_state = app
+        .try_state::<AppState>()
+        .ok_or_else(|| anyhow!("App state not available"))?;
+
+    // Delete existing transcripts for this meeting
+    delete_meeting_transcripts(app_state.db_manager.pool(), &meeting_id).await?;
+
+    // Insert new transcripts
+    insert_meeting_transcripts(app_state.db_manager.pool(), &meeting_id, &segments).await?;
+
+    // Update the meeting's transcription language
+    update_meeting_language(app_state.db_manager.pool(), &meeting_id, language.as_deref()).await?;
+
+    emit_progress(&app, &meeting_id, "complete", 100, "Retranscription complete");
+
+    Ok(RetranscriptionResult {
+        meeting_id,
+        segments_count: segments.len(),
+        duration_seconds,
+        language,
+    })
+}
+
+/// Emit progress event
+fn emit_progress<R: Runtime>(
+    app: &AppHandle<R>,
+    meeting_id: &str,
+    stage: &str,
+    progress: u32,
+    message: &str,
+) {
+    let _ = app.emit(
+        "retranscription-progress",
+        RetranscriptionProgress {
+            meeting_id: meeting_id.to_string(),
+            stage: stage.to_string(),
+            progress_percentage: progress,
+            message: message.to_string(),
+        },
+    );
+}
+
+/// Get or initialize the Whisper engine, auto-loading the model if needed
+/// If `requested_model` is provided, ensures that specific model is loaded
+async fn get_or_init_whisper<R: Runtime>(
+    app: &AppHandle<R>,
+    requested_model: Option<&str>,
+) -> Result<Arc<WhisperEngine>> {
+    use crate::whisper_engine::commands::WHISPER_ENGINE;
+
+    let engine = {
+        let guard = WHISPER_ENGINE.lock().unwrap();
+        guard.as_ref().cloned()
+    };
+
+    match engine {
+        Some(e) => {
+            // Determine which model to use
+            let target_model = match requested_model {
+                Some(model) => model.to_string(),
+                None => get_configured_whisper_model(app).await?,
+            };
+
+            // Check if the correct model is already loaded
+            let current_model = e.get_current_model().await;
+            let needs_load = match &current_model {
+                Some(loaded) => loaded != &target_model,
+                None => true,
+            };
+
+            if needs_load {
+                info!(
+                    "Loading Whisper model '{}' (current: {:?})",
+                    target_model, current_model
+                );
+
+                // Discover available models first (populates the internal cache)
+                info!("Discovering available Whisper models...");
+                if let Err(discover_err) = e.discover_models().await {
+                    warn!("Error during model discovery (continuing anyway): {}", discover_err);
+                }
+
+                match e.load_model(&target_model).await {
+                    Ok(_) => {
+                        info!("Whisper model '{}' loaded successfully", target_model);
+                        Ok(e)
+                    }
+                    Err(load_err) => {
+                        error!("Failed to load Whisper model '{}': {}", target_model, load_err);
+                        Err(anyhow!("Failed to load Whisper model '{}': {}", target_model, load_err))
+                    }
+                }
+            } else {
+                info!("Whisper model '{}' already loaded", target_model);
+                Ok(e)
+            }
+        }
+        None => Err(anyhow!("Whisper engine not initialized")),
+    }
+}
+
+/// Get the configured Whisper model name from the database
+async fn get_configured_whisper_model<R: Runtime>(app: &AppHandle<R>) -> Result<String> {
+    debug!("Getting configured Whisper model from database...");
+
+    let app_state = app
+        .try_state::<AppState>()
+        .ok_or_else(|| {
+            error!("App state not available");
+            anyhow!("App state not available")
+        })?;
+
+    debug!("Querying transcript_settings table...");
+
+    // Query the transcript settings from the database - get both provider and model
+    let result: Option<(String, String)> = sqlx::query_as(
+        "SELECT provider, model FROM transcript_settings WHERE id = '1'"
+    )
+    .fetch_optional(app_state.db_manager.pool())
+    .await
+    .map_err(|e| {
+        error!("Failed to query transcript config: {}", e);
+        anyhow!("Failed to query transcript config: {}", e)
+    })?;
+
+    match result {
+        Some((provider, model)) => {
+            info!("Found transcript config: provider={}, model={}", provider, model);
+
+            // Check if provider is Whisper-based
+            if provider == "localWhisper" || provider == "whisper" {
+                Ok(model)
+            } else {
+                error!("Retranscription requires Whisper provider, but configured provider is: {}", provider);
+                Err(anyhow!("Retranscription requires Whisper. Current provider '{}' does not support retranscription with language selection.", provider))
+            }
+        },
+        None => {
+            // Default to large-v3-turbo if no config exists
+            warn!("No transcript config found, using default model 'large-v3-turbo'");
+            Ok("large-v3-turbo".to_string())
+        }
+    }
+}
+
+/// Get or initialize the Parakeet engine, auto-loading the model if needed
+async fn get_or_init_parakeet<R: Runtime>(
+    app: &AppHandle<R>,
+    requested_model: Option<&str>,
+) -> Result<Arc<ParakeetEngine>> {
+    use crate::parakeet_engine::commands::PARAKEET_ENGINE;
+
+    let engine = {
+        let guard = PARAKEET_ENGINE.lock().unwrap();
+        guard.as_ref().cloned()
+    };
+
+    match engine {
+        Some(e) => {
+            // Determine which model to use
+            let target_model = match requested_model {
+                Some(model) => model.to_string(),
+                None => get_configured_parakeet_model(app).await?,
+            };
+
+            // Check if the correct model is already loaded
+            let current_model = e.get_current_model().await;
+            let needs_load = match &current_model {
+                Some(loaded) => loaded != &target_model,
+                None => true,
+            };
+
+            if needs_load {
+                info!(
+                    "Loading Parakeet model '{}' (current: {:?})",
+                    target_model, current_model
+                );
+
+                // Discover available models first
+                info!("Discovering available Parakeet models...");
+                if let Err(discover_err) = e.discover_models().await {
+                    warn!("Error during Parakeet model discovery (continuing anyway): {}", discover_err);
+                }
+
+                match e.load_model(&target_model).await {
+                    Ok(_) => {
+                        info!("Parakeet model '{}' loaded successfully", target_model);
+                        Ok(e)
+                    }
+                    Err(load_err) => {
+                        error!("Failed to load Parakeet model '{}': {}", target_model, load_err);
+                        Err(anyhow!("Failed to load Parakeet model '{}': {}", target_model, load_err))
+                    }
+                }
+            } else {
+                info!("Parakeet model '{}' already loaded", target_model);
+                Ok(e)
+            }
+        }
+        None => Err(anyhow!("Parakeet engine not initialized")),
+    }
+}
+
+/// Get the configured Parakeet model name from the database
+async fn get_configured_parakeet_model<R: Runtime>(app: &AppHandle<R>) -> Result<String> {
+    debug!("Getting configured Parakeet model from database...");
+
+    let app_state = app
+        .try_state::<AppState>()
+        .ok_or_else(|| {
+            error!("App state not available");
+            anyhow!("App state not available")
+        })?;
+
+    // Query the transcript settings from the database
+    let result: Option<(String, String)> = sqlx::query_as(
+        "SELECT provider, model FROM transcript_settings WHERE id = '1'"
+    )
+    .fetch_optional(app_state.db_manager.pool())
+    .await
+    .map_err(|e| {
+        error!("Failed to query transcript config: {}", e);
+        anyhow!("Failed to query transcript config: {}", e)
+    })?;
+
+    match result {
+        Some((provider, model)) => {
+            info!("Found transcript config: provider={}, model={}", provider, model);
+
+            if provider == "parakeet" {
+                Ok(model)
+            } else {
+                // Default to parakeet-tdt model
+                warn!("Configured provider is not Parakeet, using default model");
+                Ok("parakeet-tdt-0.6b-v3-int8".to_string())
+            }
+        },
+        None => {
+            // Default to parakeet-tdt model if no config exists
+            warn!("No transcript config found, using default Parakeet model");
+            Ok("parakeet-tdt-0.6b-v3-int8".to_string())
+        }
+    }
+}
+
+/// Create transcript segments from VAD-segmented transcription results
+/// Each tuple is (text, start_ms, end_ms) from VAD timestamps
+fn create_transcript_segments_from_vad(
+    transcripts: &[(String, f64, f64)],
+    _avg_confidence: f32,
+) -> Vec<TranscriptSegment> {
+    transcripts
+        .iter()
+        .map(|(text, start_ms, end_ms)| {
+            let start_seconds = start_ms / 1000.0;
+            let end_seconds = end_ms / 1000.0;
+            let duration = end_seconds - start_seconds;
+
+            TranscriptSegment {
+                id: format!("transcript-{}", Uuid::new_v4()),
+                text: text.trim().to_string(),
+                timestamp: chrono::Utc::now().to_rfc3339(),
+                audio_start_time: Some(start_seconds),
+                audio_end_time: Some(end_seconds),
+                duration: Some(duration),
+            }
+        })
+        .collect()
+}
+
+/// Delete existing transcripts for a meeting
+async fn delete_meeting_transcripts(
+    pool: &sqlx::SqlitePool,
+    meeting_id: &str,
+) -> Result<()> {
+    sqlx::query("DELETE FROM transcripts WHERE meeting_id = ?")
+        .bind(meeting_id)
+        .execute(pool)
+        .await
+        .map_err(|e| anyhow!("Failed to delete existing transcripts: {}", e))?;
+
+    info!("Deleted existing transcripts for meeting {}", meeting_id);
+    Ok(())
+}
+
+/// Insert new transcripts for a meeting
+async fn insert_meeting_transcripts(
+    pool: &sqlx::SqlitePool,
+    meeting_id: &str,
+    segments: &[TranscriptSegment],
+) -> Result<()> {
+    for segment in segments {
+        sqlx::query(
+            "INSERT INTO transcripts (id, meeting_id, transcript, timestamp, audio_start_time, audio_end_time, duration)
+             VALUES (?, ?, ?, ?, ?, ?, ?)"
+        )
+        .bind(&segment.id)
+        .bind(meeting_id)
+        .bind(&segment.text)
+        .bind(&segment.timestamp)
+        .bind(segment.audio_start_time)
+        .bind(segment.audio_end_time)
+        .bind(segment.duration)
+        .execute(pool)
+        .await
+        .map_err(|e| anyhow!("Failed to insert transcript: {}", e))?;
+    }
+
+    info!(
+        "Inserted {} transcripts for meeting {}",
+        segments.len(),
+        meeting_id
+    );
+    Ok(())
+}
+
+/// Update the transcription language for a meeting
+async fn update_meeting_language(
+    pool: &sqlx::SqlitePool,
+    meeting_id: &str,
+    language: Option<&str>,
+) -> Result<()> {
+    sqlx::query("UPDATE meetings SET transcription_language = ? WHERE id = ?")
+        .bind(language)
+        .bind(meeting_id)
+        .execute(pool)
+        .await
+        .map_err(|e| anyhow!("Failed to update meeting language: {}", e))?;
+
+    info!(
+        "Updated transcription language for meeting {} to {:?}",
+        meeting_id, language
+    );
+    Ok(())
+}
+
+// Tauri commands
+
+/// Response when retranscription is started
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetranscriptionStarted {
+    pub meeting_id: String,
+    pub message: String,
+}
+
+#[tauri::command]
+pub async fn start_retranscription_command<R: Runtime>(
+    app: AppHandle<R>,
+    meeting_id: String,
+    meeting_folder_path: String,
+    language: Option<String>,
+    model: Option<String>,
+    provider: Option<String>,
+) -> Result<RetranscriptionStarted, String> {
+    // Check if already in progress before spawning
+    if RETRANSCRIPTION_IN_PROGRESS.load(Ordering::SeqCst) {
+        return Err("Retranscription already in progress".to_string());
+    }
+
+    // Clone values for the spawned task
+    let meeting_id_clone = meeting_id.clone();
+
+    // Spawn the retranscription in a background task
+    // This allows the command to return immediately while work continues
+    tauri::async_runtime::spawn(async move {
+        let result = start_retranscription(
+            app,
+            meeting_id_clone,
+            meeting_folder_path,
+            language,
+            model,
+            provider,
+        )
+        .await;
+
+        // Errors are already emitted as events in start_retranscription
+        // so we just log here for debugging
+        if let Err(e) = result {
+            error!("Retranscription failed: {}", e);
+        }
+    });
+
+    Ok(RetranscriptionStarted {
+        meeting_id,
+        message: "Retranscription started".to_string(),
+    })
+}
+
+#[tauri::command]
+pub async fn cancel_retranscription_command() -> Result<(), String> {
+    if !is_retranscription_in_progress() {
+        return Err("No retranscription in progress".to_string());
+    }
+    cancel_retranscription();
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn is_retranscription_in_progress_command() -> bool {
+    is_retranscription_in_progress()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_transcript_segments_from_vad_empty() {
+        let transcripts: Vec<(String, f64, f64)> = vec![];
+        let segments = create_transcript_segments_from_vad(&transcripts, 0.9);
+        assert!(segments.is_empty());
+    }
+
+    #[test]
+    fn test_create_transcript_segments_from_vad_single() {
+        let transcripts = vec![
+            ("Hello world".to_string(), 0.0, 1500.0), // 0-1.5 seconds
+        ];
+        let segments = create_transcript_segments_from_vad(&transcripts, 0.9);
+
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].text, "Hello world");
+        assert_eq!(segments[0].audio_start_time, Some(0.0));
+        assert_eq!(segments[0].audio_end_time, Some(1.5));
+        assert_eq!(segments[0].duration, Some(1.5));
+    }
+
+    #[test]
+    fn test_create_transcript_segments_from_vad_multiple() {
+        let transcripts = vec![
+            ("First segment".to_string(), 0.0, 2000.0),      // 0-2 seconds
+            ("Second segment".to_string(), 3000.0, 5000.0),  // 3-5 seconds
+            ("Third segment".to_string(), 6500.0, 8000.0),   // 6.5-8 seconds
+        ];
+        let segments = create_transcript_segments_from_vad(&transcripts, 0.85);
+
+        assert_eq!(segments.len(), 3);
+
+        // First segment
+        assert_eq!(segments[0].text, "First segment");
+        assert_eq!(segments[0].audio_start_time, Some(0.0));
+        assert_eq!(segments[0].audio_end_time, Some(2.0));
+        assert_eq!(segments[0].duration, Some(2.0));
+
+        // Second segment
+        assert_eq!(segments[1].text, "Second segment");
+        assert_eq!(segments[1].audio_start_time, Some(3.0));
+        assert_eq!(segments[1].audio_end_time, Some(5.0));
+        assert_eq!(segments[1].duration, Some(2.0));
+
+        // Third segment
+        assert_eq!(segments[2].text, "Third segment");
+        assert_eq!(segments[2].audio_start_time, Some(6.5));
+        assert_eq!(segments[2].audio_end_time, Some(8.0));
+        assert_eq!(segments[2].duration, Some(1.5));
+    }
+
+    #[test]
+    fn test_create_transcript_segments_from_vad_trims_whitespace() {
+        let transcripts = vec![
+            ("  Hello with spaces  ".to_string(), 0.0, 1000.0),
+        ];
+        let segments = create_transcript_segments_from_vad(&transcripts, 0.9);
+
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].text, "Hello with spaces");
+    }
+
+    #[test]
+    fn test_create_transcript_segments_generates_unique_ids() {
+        let transcripts = vec![
+            ("Segment one".to_string(), 0.0, 1000.0),
+            ("Segment two".to_string(), 1000.0, 2000.0),
+        ];
+        let segments = create_transcript_segments_from_vad(&transcripts, 0.9);
+
+        assert_eq!(segments.len(), 2);
+        assert_ne!(segments[0].id, segments[1].id);
+        assert!(segments[0].id.starts_with("transcript-"));
+        assert!(segments[1].id.starts_with("transcript-"));
+    }
+
+    #[test]
+    fn test_cancellation_flag() {
+        // Reset flag to known state
+        RETRANSCRIPTION_CANCELLED.store(false, Ordering::SeqCst);
+        RETRANSCRIPTION_IN_PROGRESS.store(false, Ordering::SeqCst);
+
+        assert!(!is_retranscription_in_progress());
+
+        // Test cancellation
+        cancel_retranscription();
+        assert!(RETRANSCRIPTION_CANCELLED.load(Ordering::SeqCst));
+
+        // Reset for other tests
+        RETRANSCRIPTION_CANCELLED.store(false, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn test_vad_redemption_time_constant() {
+        // Ensure the constant matches live transcription settings (pipeline.rs:727)
+        assert_eq!(VAD_REDEMPTION_TIME_MS, 400);
+    }
+}

--- a/frontend/src-tauri/src/audio/vad.rs
+++ b/frontend/src-tauri/src/audio/vad.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use silero_rs::{VadConfig, VadSession, VadTransition};
-use log::{debug, info};
+use log::{debug, info, warn};
 use std::collections::VecDeque;
 use std::time::Duration;
 
@@ -161,6 +161,9 @@ impl ContinuousVadProcessor {
 
     /// Flush any remaining audio and return final speech segments
     pub fn flush(&mut self) -> Result<Vec<SpeechSegment>> {
+        debug!("VAD flush: in_speech={}, current_speech_len={}, buffer_len={}, speech_segments_queued={}",
+              self.in_speech, self.current_speech.len(), self.buffer.len(), self.speech_segments.len());
+
         let mut completed_segments = Vec::new();
 
         // Process any remaining buffered audio
@@ -181,6 +184,9 @@ impl ContinuousVadProcessor {
         if self.in_speech && !self.current_speech.is_empty() {
             let start_ms = (self.speech_start_sample as f64 / self.sample_rate as f64) * 1000.0;
             let end_ms = (self.processed_samples as f64 / self.sample_rate as f64) * 1000.0;
+
+            debug!("VAD flush: Force-ending speech - start={}ms, end={}ms, duration={}ms, samples={}",
+                  start_ms, end_ms, end_ms - start_ms, self.current_speech.len());
 
             let segment = SpeechSegment {
                 samples: self.current_speech.clone(),
@@ -203,8 +209,21 @@ impl ContinuousVadProcessor {
     }
 
     fn process_chunk(&mut self, chunk: &[f32]) -> Result<()> {
+        // Track accumulated speech buffer size to detect memory issues
+        let current_speech_size = self.current_speech.len();
+        if current_speech_size > 1_000_000 {
+            // More than ~62 seconds of accumulated speech at 16kHz
+            warn!("VAD: Accumulated speech buffer is large: {} samples ({:.1}s) - possible memory issue",
+                  current_speech_size, current_speech_size as f64 / 16000.0);
+        }
+
         let transitions = self.session.process(chunk)
             .map_err(|e| anyhow!("VAD processing failed: {}", e))?;
+
+        // Log transitions for debugging
+        if !transitions.is_empty() {
+            debug!("VAD transitions at sample {}: {} transitions", self.processed_samples, transitions.len());
+        }
 
         // Handle VAD transitions
         for transition in transitions {
@@ -212,7 +231,7 @@ impl ContinuousVadProcessor {
                 VadTransition::SpeechStart { timestamp_ms } => {
                     // Only log if state changed
                     if !self.last_logged_state {
-                        info!("VAD: Speech started at {}ms", timestamp_ms);
+                        debug!("VAD: Speech started at {}ms", timestamp_ms);
                         self.last_logged_state = true;
                     }
                     self.in_speech = true;
@@ -222,7 +241,7 @@ impl ContinuousVadProcessor {
                 VadTransition::SpeechEnd { start_timestamp_ms, end_timestamp_ms, samples } => {
                     // Only log if we were previously in speech state
                     if self.last_logged_state {
-                        info!("VAD: Speech ended at {}ms (duration: {}ms)", end_timestamp_ms, end_timestamp_ms - start_timestamp_ms);
+                        debug!("VAD: Speech ended at {}ms (duration: {}ms)", end_timestamp_ms, end_timestamp_ms - start_timestamp_ms);
                         self.last_logged_state = false;
                     }
                     self.in_speech = false;
@@ -306,14 +325,216 @@ pub fn extract_speech_16k(samples_mono_16k: &[f32]) -> Result<Vec<f32>> {
 /// Simple convenience function to get speech chunks from audio
 /// Uses the optimized ContinuousVadProcessor with configurable redemption time
 pub fn get_speech_chunks(samples_mono_16k: &[f32], redemption_time_ms: u32) -> Result<Vec<SpeechSegment>> {
-    let mut processor = ContinuousVadProcessor::new(16000, redemption_time_ms)?;
-
-    // Process all audio
-    let mut segments = processor.process_audio(samples_mono_16k)?;
-    let final_segments = processor.flush()?;
-    segments.extend(final_segments);
-
-    Ok(segments)
+    get_speech_chunks_with_progress(samples_mono_16k, redemption_time_ms, |_, _| true)
 }
 
- 
+/// Get speech chunks with progress callback and cancellation support
+/// The callback receives (progress_percent, segments_found) and returns false to cancel
+pub fn get_speech_chunks_with_progress<F>(
+    samples_mono_16k: &[f32],
+    redemption_time_ms: u32,
+    mut progress_callback: F,
+) -> Result<Vec<SpeechSegment>>
+where
+    F: FnMut(u32, usize) -> bool,
+{
+    let mut processor = ContinuousVadProcessor::new(16000, redemption_time_ms)?;
+
+    let total_samples = samples_mono_16k.len();
+
+    // For large files (>1 minute at 16kHz = 960,000 samples), process in chunks with progress logging
+    const LARGE_FILE_THRESHOLD: usize = 960_000;
+    const CHUNK_SIZE: usize = 160_000; // 10 seconds at 16kHz
+
+    let mut all_segments = Vec::new();
+
+    if total_samples > LARGE_FILE_THRESHOLD {
+        info!("VAD: Processing large file ({} samples = {:.1}s), will log progress...",
+              total_samples, total_samples as f64 / 16000.0);
+
+        let mut processed = 0;
+        let mut last_progress = 0u32;
+        let mut chunk_count = 0;
+        let total_chunks = (total_samples + CHUNK_SIZE - 1) / CHUNK_SIZE;
+
+        for chunk in samples_mono_16k.chunks(CHUNK_SIZE) {
+            chunk_count += 1;
+
+            let start_time = std::time::Instant::now();
+            let segments = processor.process_audio(chunk)?;
+            let elapsed = start_time.elapsed();
+
+            // Debug log for chunk processing details
+            debug!("VAD: Chunk {}/{} processed in {:?}, found {} segments",
+                  chunk_count, total_chunks, elapsed, segments.len());
+
+            // Warn if chunk processing took too long (>1 second)
+            if elapsed.as_secs() > 1 {
+                warn!("VAD: Chunk {} took {:?} - possible performance issue", chunk_count, elapsed);
+            }
+
+            all_segments.extend(segments);
+
+            processed += chunk.len();
+            let progress = ((processed * 100) / total_samples) as u32;
+
+            // Call progress callback every 5%
+            if progress >= last_progress + 5 {
+                debug!("VAD: Progress {}% ({} segments found so far)", progress, all_segments.len());
+
+                // Check for cancellation
+                if !progress_callback(progress, all_segments.len()) {
+                    info!("VAD: Cancelled by callback at {}%", progress);
+                    return Err(anyhow!("VAD processing cancelled"));
+                }
+
+                last_progress = progress;
+            }
+        }
+
+        let final_segments = processor.flush()?;
+        all_segments.extend(final_segments);
+
+        info!("VAD: Complete! Found {} speech segments", all_segments.len());
+    } else {
+        // Small file - process all at once
+        all_segments = processor.process_audio(samples_mono_16k)?;
+        let final_segments = processor.flush()?;
+        all_segments.extend(final_segments);
+    }
+
+    Ok(all_segments)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Generate synthetic speech-like audio with alternating speech/silence
+    fn generate_test_audio_with_speech(duration_seconds: f32, sample_rate: u32) -> Vec<f32> {
+        let total_samples = (duration_seconds * sample_rate as f32) as usize;
+        let mut samples = vec![0.0f32; total_samples];
+
+        // Create speech-like patterns: bursts of sine waves with varying amplitude
+        // Speech every 10 seconds for 5 seconds
+        let speech_interval = 10.0; // seconds between speech starts
+        let speech_duration = 5.0;  // seconds of speech
+
+        for i in 0..total_samples {
+            let time = i as f32 / sample_rate as f32;
+            let cycle_time = time % speech_interval;
+
+            // Speech occurs in the first `speech_duration` seconds of each cycle
+            if cycle_time < speech_duration {
+                // Generate speech-like signal: multiple frequencies with amplitude modulation
+                let freq1 = 200.0 + (time * 50.0).sin() * 100.0; // Varying fundamental
+                let freq2 = freq1 * 2.0; // Harmonic
+                let freq3 = freq1 * 3.0; // Another harmonic
+
+                let amplitude = 0.3 + 0.1 * (time * 5.0).sin(); // Amplitude modulation
+                samples[i] = amplitude * (
+                    0.5 * (2.0 * std::f32::consts::PI * freq1 * time).sin() +
+                    0.3 * (2.0 * std::f32::consts::PI * freq2 * time).sin() +
+                    0.2 * (2.0 * std::f32::consts::PI * freq3 * time).sin()
+                );
+            }
+            // else: silence (already 0.0)
+        }
+
+        samples
+    }
+
+    #[test]
+    fn test_vad_chunked_vs_single_processing() {
+        // Generate 60 seconds of audio with speech patterns at 16kHz
+        let audio = generate_test_audio_with_speech(60.0, 16000);
+        println!("Generated {} samples ({:.1}s)", audio.len(), audio.len() as f32 / 16000.0);
+
+        // Process all at once (like small files)
+        let segments_single = get_speech_chunks(&audio, 2000).expect("Single processing failed");
+        println!("Single processing found {} segments", segments_single.len());
+
+        // Process in chunks (like large files)
+        let segments_chunked = get_speech_chunks_with_progress(&audio, 2000, |progress, segments| {
+            println!("Chunked progress: {}%, {} segments", progress, segments);
+            true // Don't cancel
+        }).expect("Chunked processing failed");
+        println!("Chunked processing found {} segments", segments_chunked.len());
+
+        // Both should find the same number of segments (approximately)
+        // Allow some variance due to chunk boundary effects
+        let diff = (segments_single.len() as i32 - segments_chunked.len() as i32).abs();
+        assert!(diff <= 1,
+            "Chunked and single processing found different segment counts: {} vs {} (diff: {})",
+            segments_single.len(), segments_chunked.len(), diff);
+    }
+
+    #[test]
+    fn test_vad_large_file_progress() {
+        // Generate 120 seconds (2 minutes) of audio - triggers large file threshold
+        let audio = generate_test_audio_with_speech(120.0, 16000);
+        let total_samples = audio.len();
+        println!("Generated {} samples ({:.1}s)", total_samples, total_samples as f32 / 16000.0);
+
+        // This should trigger the large file path (>960,000 samples)
+        assert!(total_samples > 960_000, "Audio should be large enough to trigger chunked processing");
+
+        let mut progress_updates = Vec::new();
+        let segments = get_speech_chunks_with_progress(&audio, 2000, |progress, segments| {
+            progress_updates.push((progress, segments));
+            true // Don't cancel
+        }).expect("Processing failed");
+
+        println!("Found {} segments with {} progress updates", segments.len(), progress_updates.len());
+
+        // Should have found multiple speech segments (one every 10 seconds)
+        // 120 seconds / 10 second interval = 12 expected speech bursts
+        assert!(segments.len() >= 6, "Expected at least 6 speech segments, found {}", segments.len());
+
+        // Should have received progress updates
+        assert!(!progress_updates.is_empty(), "Expected progress updates for large file");
+    }
+
+    #[test]
+    fn test_vad_cancellation() {
+        let audio = generate_test_audio_with_speech(120.0, 16000);
+
+        // Cancel at 50%
+        let result = get_speech_chunks_with_progress(&audio, 2000, |progress, _| {
+            progress < 50 // Cancel when reaching 50%
+        });
+
+        // Should return error due to cancellation
+        assert!(result.is_err(), "Expected cancellation error");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("cancelled"), "Error should mention cancellation: {}", err_msg);
+    }
+
+    #[test]
+    fn test_vad_continuous_processor_state_across_chunks() {
+        // Test that VAD state is correctly maintained across chunk boundaries
+        let mut processor = ContinuousVadProcessor::new(16000, 2000).expect("Failed to create processor");
+
+        // Generate audio with a speech segment that spans a chunk boundary
+        let chunk_size = 160_000; // 10 seconds
+        let audio = generate_test_audio_with_speech(30.0, 16000); // 30 seconds
+
+        // Process in 10-second chunks
+        let mut all_segments = Vec::new();
+        for (i, chunk) in audio.chunks(chunk_size).enumerate() {
+            let segments = processor.process_audio(chunk).expect("Processing failed");
+            println!("Chunk {}: processed {} samples, found {} segments", i, chunk.len(), segments.len());
+            all_segments.extend(segments);
+        }
+
+        // Flush remaining
+        let final_segments = processor.flush().expect("Flush failed");
+        all_segments.extend(final_segments);
+
+        println!("Total segments found: {}", all_segments.len());
+
+        // Should find speech segments
+        assert!(all_segments.len() >= 1, "Expected at least 1 speech segment");
+    }
+}
+

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -710,6 +710,10 @@ pub fn run() {
             // System settings commands
             #[cfg(target_os = "macos")]
             utils::open_system_settings,
+            // Retranscription commands
+            audio::retranscription::start_retranscription_command,
+            audio::retranscription::cancel_retranscription_command,
+            audio::retranscription::is_retranscription_in_progress_command,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/frontend/src/app/meeting-details/page-content.tsx
+++ b/frontend/src/app/meeting-details/page-content.tsx
@@ -166,6 +166,9 @@ export default function PageContent({
           totalCount={totalCount}
           loadedCount={loadedCount}
           onLoadMore={onLoadMore}
+          // Retranscription props
+          meetingId={meeting.id}
+          meetingFolderPath={meeting.folder_path}
         />
         <SummaryPanel
           meeting={meeting}

--- a/frontend/src/app/meeting-details/page.tsx
+++ b/frontend/src/app/meeting-details/page.tsx
@@ -16,6 +16,7 @@ interface MeetingDetailsResponse {
   created_at: string;
   updated_at: string;
   transcripts: Transcript[];
+  folder_path?: string;
 }
 
 function MeetingDetailsContent() {
@@ -131,6 +132,7 @@ function MeetingDetailsContent() {
         created_at: metadata.created_at,
         updated_at: metadata.updated_at,
         transcripts: transcripts, // Paginated transcripts from hook
+        folder_path: metadata.folder_path, // For retranscription feature
       });
 
       // Sync with sidebar context

--- a/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
+++ b/frontend/src/components/MeetingDetails/RetranscribeDialog.tsx
@@ -1,0 +1,468 @@
+import React, { useState, useEffect } from 'react';
+import { RefreshCw, Globe, Loader2, AlertCircle, CheckCircle2, X, Cpu } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import { Button } from '../ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../ui/select';
+import { invoke } from '@tauri-apps/api/core';
+import { listen, UnlistenFn } from '@tauri-apps/api/event';
+import { toast } from 'sonner';
+import { useConfig } from '@/contexts/ConfigContext';
+
+// ISO 639-1 language codes supported by Whisper
+const LANGUAGES = [
+  { code: 'auto', name: 'Auto Detect (Original Language)' },
+  { code: 'auto-translate', name: 'Auto Detect (Translate to English)' },
+  { code: 'en', name: 'English' },
+  { code: 'zh', name: 'Chinese' },
+  { code: 'de', name: 'German' },
+  { code: 'es', name: 'Spanish' },
+  { code: 'ru', name: 'Russian' },
+  { code: 'ko', name: 'Korean' },
+  { code: 'fr', name: 'French' },
+  { code: 'ja', name: 'Japanese' },
+  { code: 'pt', name: 'Portuguese' },
+  { code: 'tr', name: 'Turkish' },
+  { code: 'pl', name: 'Polish' },
+  { code: 'ca', name: 'Catalan' },
+  { code: 'nl', name: 'Dutch' },
+  { code: 'ar', name: 'Arabic' },
+  { code: 'sv', name: 'Swedish' },
+  { code: 'it', name: 'Italian' },
+  { code: 'id', name: 'Indonesian' },
+  { code: 'hi', name: 'Hindi' },
+  { code: 'fi', name: 'Finnish' },
+  { code: 'vi', name: 'Vietnamese' },
+  { code: 'he', name: 'Hebrew' },
+  { code: 'uk', name: 'Ukrainian' },
+  { code: 'el', name: 'Greek' },
+  { code: 'ms', name: 'Malay' },
+  { code: 'cs', name: 'Czech' },
+  { code: 'ro', name: 'Romanian' },
+  { code: 'da', name: 'Danish' },
+  { code: 'hu', name: 'Hungarian' },
+  { code: 'ta', name: 'Tamil' },
+  { code: 'no', name: 'Norwegian' },
+  { code: 'th', name: 'Thai' },
+  { code: 'ur', name: 'Urdu' },
+  { code: 'hr', name: 'Croatian' },
+  { code: 'bg', name: 'Bulgarian' },
+  { code: 'lt', name: 'Lithuanian' },
+];
+
+interface RetranscribeDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  meetingId: string;
+  meetingFolderPath: string | null;
+  onComplete?: () => void;
+}
+
+interface RetranscriptionProgress {
+  meeting_id: string;
+  stage: string;
+  progress_percentage: number;
+  message: string;
+}
+
+interface RetranscriptionResult {
+  meeting_id: string;
+  segments_count: number;
+  duration_seconds: number;
+  language: string | null;
+}
+
+interface RetranscriptionError {
+  meeting_id: string;
+  error: string;
+}
+
+interface RawModelInfo {
+  name: string;
+  size_mb: number;
+  status: 'Available' | 'Missing' | { Downloading: { progress: number } } | { Error: string } | { Corrupted: { file_size: number; expected_min_size: number } };
+}
+
+interface ModelOption {
+  provider: 'whisper' | 'parakeet';
+  name: string;
+  displayName: string;
+  size_mb: number;
+}
+
+export function RetranscribeDialog({
+  open,
+  onOpenChange,
+  meetingId,
+  meetingFolderPath,
+  onComplete,
+}: RetranscribeDialogProps) {
+  const { selectedLanguage, transcriptModelConfig } = useConfig();
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [progress, setProgress] = useState<RetranscriptionProgress | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedLang, setSelectedLang] = useState(selectedLanguage || 'auto');
+  const [availableModels, setAvailableModels] = useState<ModelOption[]>([]);
+  const [selectedModelKey, setSelectedModelKey] = useState<string>(''); // Format: "provider:model"
+  const [loadingModels, setLoadingModels] = useState(false);
+
+  // Helper to get selected model details
+  const getSelectedModel = (): ModelOption | undefined => {
+    if (!selectedModelKey) return undefined;
+    const [provider, name] = selectedModelKey.split(':');
+    return availableModels.find(m => m.provider === provider && m.name === name);
+  };
+
+  // Reset state and fetch models when dialog opens
+  useEffect(() => {
+    if (open) {
+      setIsProcessing(false);
+      setProgress(null);
+      setError(null);
+      setSelectedLang(selectedLanguage || 'auto');
+
+      // Fetch available models from both Whisper and Parakeet
+      const fetchModels = async () => {
+        setLoadingModels(true);
+        const allModels: ModelOption[] = [];
+
+        // Fetch Whisper models
+        try {
+          const whisperModels = await invoke<RawModelInfo[]>('whisper_get_available_models');
+          const availableWhisper = whisperModels
+            .filter(m => m.status === 'Available')
+            .map(m => ({
+              provider: 'whisper' as const,
+              name: m.name,
+              displayName: `🏠 Whisper: ${m.name}`,
+              size_mb: m.size_mb,
+            }));
+          allModels.push(...availableWhisper);
+        } catch (err) {
+          console.error('Failed to fetch Whisper models:', err);
+        }
+
+        // Fetch Parakeet models
+        try {
+          const parakeetModels = await invoke<RawModelInfo[]>('parakeet_get_available_models');
+          const availableParakeet = parakeetModels
+            .filter(m => m.status === 'Available')
+            .map(m => ({
+              provider: 'parakeet' as const,
+              name: m.name,
+              displayName: `⚡ Parakeet: ${m.name}`,
+              size_mb: m.size_mb,
+            }));
+          allModels.push(...availableParakeet);
+        } catch (err) {
+          console.error('Failed to fetch Parakeet models:', err);
+        }
+
+        setAvailableModels(allModels);
+
+        // Set default model based on current transcript config
+        const configuredProvider = transcriptModelConfig?.provider || '';
+        const configuredModel = transcriptModelConfig?.model || '';
+
+        // Try to match configured model
+        const configuredMatch = allModels.find(m =>
+          (configuredProvider === 'localWhisper' && m.provider === 'whisper' && m.name === configuredModel) ||
+          (configuredProvider === 'parakeet' && m.provider === 'parakeet' && m.name === configuredModel)
+        );
+
+        if (configuredMatch) {
+          setSelectedModelKey(`${configuredMatch.provider}:${configuredMatch.name}`);
+        } else if (allModels.length > 0) {
+          // Default to first available model
+          setSelectedModelKey(`${allModels[0].provider}:${allModels[0].name}`);
+        }
+
+        setLoadingModels(false);
+      };
+      fetchModels();
+    }
+  }, [open, selectedLanguage, transcriptModelConfig]);
+
+  // Listen for retranscription events
+  useEffect(() => {
+    if (!open) return;
+
+    const unlisteners: UnlistenFn[] = [];
+
+    const setupListeners = async () => {
+      // Progress events
+      const unlistenProgress = await listen<RetranscriptionProgress>(
+        'retranscription-progress',
+        (event) => {
+          if (event.payload.meeting_id === meetingId) {
+            setProgress(event.payload);
+          }
+        }
+      );
+      unlisteners.push(unlistenProgress);
+
+      // Completion event
+      const unlistenComplete = await listen<RetranscriptionResult>(
+        'retranscription-complete',
+        (event) => {
+          if (event.payload.meeting_id === meetingId) {
+            setIsProcessing(false);
+            toast.success(
+              `Retranscription complete! ${event.payload.segments_count} segments created.`
+            );
+            onComplete?.();
+            onOpenChange(false);
+          }
+        }
+      );
+      unlisteners.push(unlistenComplete);
+
+      // Error event
+      const unlistenError = await listen<RetranscriptionError>(
+        'retranscription-error',
+        (event) => {
+          if (event.payload.meeting_id === meetingId) {
+            setIsProcessing(false);
+            setError(event.payload.error);
+          }
+        }
+      );
+      unlisteners.push(unlistenError);
+    };
+
+    setupListeners();
+
+    return () => {
+      unlisteners.forEach((unlisten) => unlisten());
+    };
+  }, [open, meetingId, onComplete, onOpenChange]);
+
+  const handleStartRetranscription = async () => {
+    if (!meetingFolderPath) {
+      setError('Meeting folder path not available');
+      return;
+    }
+
+    setIsProcessing(true);
+    setError(null);
+    setProgress(null);
+
+    try {
+      const selectedModelDetails = getSelectedModel();
+      await invoke('start_retranscription_command', {
+        meetingId,
+        meetingFolderPath,
+        language: selectedLang === 'auto' ? null : selectedLang,
+        model: selectedModelDetails?.name || null,
+        provider: selectedModelDetails?.provider || null,
+      });
+    } catch (err: any) {
+      setIsProcessing(false);
+      setError(err.message || 'Failed to start retranscription');
+    }
+  };
+
+  const handleCancel = async () => {
+    if (isProcessing) {
+      try {
+        await invoke('cancel_retranscription_command');
+        setIsProcessing(false);
+        setProgress(null);
+        toast.info('Retranscription cancelled');
+      } catch (err) {
+        console.error('Failed to cancel retranscription:', err);
+      }
+    }
+    onOpenChange(false);
+  };
+
+  // Prevent closing during processing
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen && isProcessing) {
+      return;
+    }
+    onOpenChange(newOpen);
+  };
+
+  const handleEscapeKeyDown = (event: KeyboardEvent) => {
+    if (isProcessing) {
+      event.preventDefault();
+    }
+  };
+
+  const handleInteractOutside = (event: Event) => {
+    if (isProcessing) {
+      event.preventDefault();
+    }
+  };
+
+  const getLanguageName = (code: string) => {
+    return LANGUAGES.find((l) => l.code === code)?.name || code;
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="sm:max-w-[450px]"
+        onEscapeKeyDown={handleEscapeKeyDown}
+        onInteractOutside={handleInteractOutside}
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {isProcessing ? (
+              <>
+                <Loader2 className="h-5 w-5 animate-spin text-blue-600" />
+                Retranscribing...
+              </>
+            ) : error ? (
+              <>
+                <AlertCircle className="h-5 w-5 text-red-600" />
+                Retranscription Failed
+              </>
+            ) : (
+              <>
+                <RefreshCw className="h-5 w-5 text-blue-600" />
+                Retranscribe Meeting
+              </>
+            )}
+          </DialogTitle>
+          <DialogDescription>
+            {isProcessing
+              ? progress?.message || 'Processing audio...'
+              : error
+              ? 'An error occurred during retranscription'
+              : 'Re-process the audio with different language settings'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {!isProcessing && !error && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <Globe className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm font-medium">Language</span>
+              </div>
+              <Select value={selectedLang} onValueChange={setSelectedLang}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select language" />
+                </SelectTrigger>
+                <SelectContent className="max-h-60">
+                  {LANGUAGES.map((lang) => (
+                    <SelectItem key={lang.code} value={lang.code}>
+                      {lang.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Select a specific language to improve accuracy, or use auto-detect
+              </p>
+            </div>
+          )}
+
+          {!isProcessing && !error && availableModels.length > 0 && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <Cpu className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm font-medium">Model</span>
+              </div>
+              <Select value={selectedModelKey} onValueChange={setSelectedModelKey} disabled={loadingModels}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder={loadingModels ? "Loading models..." : "Select model"} />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableModels.map((model) => (
+                    <SelectItem key={`${model.provider}:${model.name}`} value={`${model.provider}:${model.name}`}>
+                      {model.displayName} ({Math.round(model.size_mb)} MB)
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Choose a transcription model
+              </p>
+            </div>
+          )}
+
+          {isProcessing && progress && (
+            <div className="space-y-2">
+              <div className="relative">
+                <div className="w-full bg-gray-200 rounded-full h-3">
+                  <div
+                    className="bg-blue-600 h-3 rounded-full transition-all duration-300 ease-out"
+                    style={{ width: `${Math.min(progress.progress_percentage, 100)}%` }}
+                  />
+                </div>
+                <div className="flex justify-between text-xs text-gray-600 mt-1">
+                  <span>{progress.stage}</span>
+                  <span>{Math.round(progress.progress_percentage)}%</span>
+                </div>
+              </div>
+              <p className="text-sm text-muted-foreground text-center">
+                {progress.message}
+              </p>
+            </div>
+          )}
+
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-3">
+              <p className="text-sm text-red-800">{error}</p>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          {!isProcessing && !error && (
+            <>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handleStartRetranscription}
+                className="bg-blue-600 hover:bg-blue-700"
+                disabled={!meetingFolderPath}
+              >
+                <RefreshCw className="h-4 w-4 mr-2" />
+                Start Retranscription
+              </Button>
+            </>
+          )}
+          {isProcessing && (
+            <Button variant="outline" onClick={handleCancel}>
+              <X className="h-4 w-4 mr-2" />
+              Cancel
+            </Button>
+          )}
+          {error && (
+            <>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Close
+              </Button>
+              <Button
+                onClick={() => {
+                  setError(null);
+                  setProgress(null);
+                }}
+                variant="outline"
+              >
+                Try Again
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/MeetingDetails/TranscriptButtonGroup.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptButtonGroup.tsx
@@ -1,23 +1,36 @@
 "use client";
 
+import { useState, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
-import { Copy, FolderOpen } from 'lucide-react';
+import { Copy, FolderOpen, RefreshCw } from 'lucide-react';
 import Analytics from '@/lib/analytics';
+import { RetranscribeDialog } from './RetranscribeDialog';
 
 
 interface TranscriptButtonGroupProps {
   transcriptCount: number;
   onCopyTranscript: () => void;
   onOpenMeetingFolder: () => Promise<void>;
+  meetingId?: string;
+  meetingFolderPath?: string | null;
 }
 
 
 export function TranscriptButtonGroup({
   transcriptCount,
   onCopyTranscript,
-  onOpenMeetingFolder
+  onOpenMeetingFolder,
+  meetingId,
+  meetingFolderPath,
 }: TranscriptButtonGroupProps) {
+  const [showRetranscribeDialog, setShowRetranscribeDialog] = useState(false);
+
+  const handleRetranscribeComplete = useCallback(() => {
+    // Reload the page to show updated transcripts
+    window.location.reload();
+  }, []);
+
   return (
     <div className="flex items-center justify-center w-full gap-2">
       <ButtonGroup>
@@ -48,7 +61,33 @@ export function TranscriptButtonGroup({
           <FolderOpen className="xl:mr-2" size={18} />
           <span className="hidden lg:inline">Recording</span>
         </Button>
+
+        {meetingId && meetingFolderPath && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="xl:px-4"
+            onClick={() => {
+              Analytics.trackButtonClick('retranscribe', 'meeting_details');
+              setShowRetranscribeDialog(true);
+            }}
+            title="Retranscribe with different language"
+          >
+            <RefreshCw className="xl:mr-2" size={18} />
+            <span className="hidden lg:inline">Retranscribe</span>
+          </Button>
+        )}
       </ButtonGroup>
+
+      {meetingId && meetingFolderPath && (
+        <RetranscribeDialog
+          open={showRetranscribeDialog}
+          onOpenChange={setShowRetranscribeDialog}
+          meetingId={meetingId}
+          meetingFolderPath={meetingFolderPath}
+          onComplete={handleRetranscribeComplete}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
+++ b/frontend/src/components/MeetingDetails/TranscriptPanel.tsx
@@ -23,6 +23,10 @@ interface TranscriptPanelProps {
   totalCount?: number;
   loadedCount?: number;
   onLoadMore?: () => void;
+
+  // Retranscription props
+  meetingId?: string;
+  meetingFolderPath?: string | null;
 }
 
 export function TranscriptPanel({
@@ -40,6 +44,8 @@ export function TranscriptPanel({
   totalCount,
   loadedCount,
   onLoadMore,
+  meetingId,
+  meetingFolderPath,
 }: TranscriptPanelProps) {
   // Convert transcripts to segments if pagination is not used but we want virtualization
   const convertedSegments = useMemo(() => {
@@ -64,6 +70,8 @@ export function TranscriptPanel({
           transcriptCount={usePagination ? (totalCount ?? convertedSegments.length) : (transcripts?.length || 0)}
           onCopyTranscript={onCopyTranscript}
           onOpenMeetingFolder={onOpenMeetingFolder}
+          meetingId={meetingId}
+          meetingFolderPath={meetingFolderPath}
         />
       </div>
 

--- a/frontend/src/hooks/meeting-details/useRetranscription.ts
+++ b/frontend/src/hooks/meeting-details/useRetranscription.ts
@@ -1,0 +1,149 @@
+import { useState, useEffect, useCallback } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen, UnlistenFn } from '@tauri-apps/api/event';
+
+export interface RetranscriptionProgress {
+  meeting_id: string;
+  stage: string;
+  progress_percentage: number;
+  message: string;
+}
+
+export interface RetranscriptionResult {
+  meeting_id: string;
+  segments_count: number;
+  duration_seconds: number;
+  language: string | null;
+}
+
+export interface RetranscriptionError {
+  meeting_id: string;
+  error: string;
+}
+
+export type RetranscriptionStatus = 'idle' | 'processing' | 'complete' | 'error';
+
+export interface UseRetranscriptionOptions {
+  meetingId: string;
+  onComplete?: (result: RetranscriptionResult) => void;
+  onError?: (error: string) => void;
+}
+
+export interface UseRetranscriptionReturn {
+  status: RetranscriptionStatus;
+  progress: RetranscriptionProgress | null;
+  error: string | null;
+  isProcessing: boolean;
+  startRetranscription: (folderPath: string, language?: string | null, model?: string | null) => Promise<void>;
+  cancelRetranscription: () => Promise<void>;
+  reset: () => void;
+}
+
+export function useRetranscription({
+  meetingId,
+  onComplete,
+  onError,
+}: UseRetranscriptionOptions): UseRetranscriptionReturn {
+  const [status, setStatus] = useState<RetranscriptionStatus>('idle');
+  const [progress, setProgress] = useState<RetranscriptionProgress | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Set up event listeners
+  useEffect(() => {
+    const unlisteners: UnlistenFn[] = [];
+
+    const setupListeners = async () => {
+      // Progress events
+      const unlistenProgress = await listen<RetranscriptionProgress>(
+        'retranscription-progress',
+        (event) => {
+          if (event.payload.meeting_id === meetingId) {
+            setProgress(event.payload);
+            setStatus('processing');
+          }
+        }
+      );
+      unlisteners.push(unlistenProgress);
+
+      // Completion event
+      const unlistenComplete = await listen<RetranscriptionResult>(
+        'retranscription-complete',
+        (event) => {
+          if (event.payload.meeting_id === meetingId) {
+            setStatus('complete');
+            setProgress(null);
+            onComplete?.(event.payload);
+          }
+        }
+      );
+      unlisteners.push(unlistenComplete);
+
+      // Error event
+      const unlistenError = await listen<RetranscriptionError>(
+        'retranscription-error',
+        (event) => {
+          if (event.payload.meeting_id === meetingId) {
+            setStatus('error');
+            setError(event.payload.error);
+            onError?.(event.payload.error);
+          }
+        }
+      );
+      unlisteners.push(unlistenError);
+    };
+
+    setupListeners();
+
+    return () => {
+      unlisteners.forEach((unlisten) => unlisten());
+    };
+  }, [meetingId, onComplete, onError]);
+
+  const startRetranscription = useCallback(
+    async (folderPath: string, language?: string | null, model?: string | null) => {
+      setStatus('processing');
+      setError(null);
+      setProgress(null);
+
+      try {
+        await invoke('start_retranscription_command', {
+          meetingId,
+          meetingFolderPath: folderPath,
+          language: language || null,
+          model: model || null,
+        });
+      } catch (err: any) {
+        setStatus('error');
+        setError(err.message || 'Failed to start retranscription');
+        onError?.(err.message || 'Failed to start retranscription');
+      }
+    },
+    [meetingId, onError]
+  );
+
+  const cancelRetranscription = useCallback(async () => {
+    try {
+      await invoke('cancel_retranscription_command');
+      setStatus('idle');
+      setProgress(null);
+    } catch (err: any) {
+      console.error('Failed to cancel retranscription:', err);
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    setStatus('idle');
+    setProgress(null);
+    setError(null);
+  }, []);
+
+  return {
+    status,
+    progress,
+    error,
+    isProcessing: status === 'processing',
+    startRetranscription,
+    cancelRetranscription,
+    reset,
+  };
+}


### PR DESCRIPTION
## Summary

Allow users to retranscribe existing meeting recordings with different language settings or transcription models. This is useful when:
- Automatic language detection chose incorrectly
- A better transcription model becomes available
- User wants to try different language settings

## Key Changes

- **Audio decoder module** (`decoder.rs`) - Uses Symphonia for MP4/AAC decoding with audio normalization
- **Retranscription module** (`retranscription.rs`) - VAD-based chunking matching live transcription approach
- **RetranscribeDialog UI** - Language and model selection with progress tracking
- **useRetranscription hook** - React hook for managing retranscription state/progress
- **VAD fix** - Changed redemption time from 2000ms to 400ms to match live transcription settings

## Technical Details

- Retranscription runs in a background task to prevent UI blocking
- Uses the same VAD (Voice Activity Detection) as live transcription for consistent segment boundaries
- Audio samples are normalized to handle files with values outside -1.0 to 1.0 range
- Large segments (>25s) are automatically split to avoid transcription engine limits

## Test Plan

- [x] Unit tests for decoder (16 tests passing)
- [x] Unit tests for retranscription (7 tests passing)
- [x] Manual testing with 35-minute meeting recording
- [x] Verified ~200 segments detected (vs 1 giant segment before fix)