### PR TITLE
fix(audio): ensure directories are created on first run

### DIFF
--- a/frontend/src-tauri/src/audio/incremental_saver.rs
+++ b/frontend/src-tauri/src/audio/incremental_saver.rs
@@ -34,9 +34,13 @@ impl IncrementalAudioSaver {
     pub fn new(meeting_folder: PathBuf, sample_rate: u32) -> Result<Self> {
         let checkpoints_dir = meeting_folder.join(".checkpoints");
 
-        // Verify checkpoints directory exists
+        // Create checkpoints directory if it doesn't exist (fixes first-run audio save issue)
+        // On first installation, the directory may not exist yet, so we create it defensively
+        // rather than failing. This ensures audio recordings are saved from the very first use.
         if !checkpoints_dir.exists() {
-            return Err(anyhow!("Checkpoints directory does not exist: {}", checkpoints_dir.display()));
+            info!("Creating checkpoints directory: {}", checkpoints_dir.display());
+            std::fs::create_dir_all(&checkpoints_dir)
+                .map_err(|e| anyhow!("Failed to create checkpoints directory {}: {}", checkpoints_dir.display(), e))?;
         }
 
         Ok(Self {

--- a/frontend/src-tauri/src/audio/recording_saver.rs
+++ b/frontend/src-tauri/src/audio/recording_saver.rs
@@ -231,6 +231,15 @@ impl RecordingSaver {
         // Load preferences to get base recordings folder
         let base_folder = super::recording_preferences::get_default_recordings_folder();
 
+        // Ensure base recordings directory exists (critical for first-run scenarios)
+        // On first installation, this directory won't exist yet and must be created
+        // before we can create meeting subfolders within it.
+        if !base_folder.exists() {
+            info!("Creating base recordings directory: {}", base_folder.display());
+            std::fs::create_dir_all(&base_folder)
+                .map_err(|e| anyhow::anyhow!("Failed to create recordings directory {}: {}", base_folder.display(), e))?;
+        }
+
         // Create meeting folder structure (with or without .checkpoints/ subdirectory)
         let meeting_folder = create_meeting_folder(&base_folder, meeting_name, create_checkpoints)?;
 


### PR DESCRIPTION
## Summary
- Fixes audio recordings not being saved on first installation (#307)
- Creates `.checkpoints` directory defensively in `IncrementalAudioSaver::new()`
- Creates base recordings directory in `RecordingSaver::initialize_meeting_folder()`

## Root Cause
On first run, `IncrementalAudioSaver::new()` checked if `.checkpoints` existed and returned an error if it didn't. This error was caught but recording continued without the saver initialized, causing audio chunks to be silently discarded.

## Changes
| File | Change |
| `frontend/src-tauri/src/audio/incremental_saver.rs` | Create `.checkpoints` directory if missing instead of failing |
| `frontend/src-tauri/src/audio/recording_saver.rs` | Create base recordings directory if missing before initialization |

## Test Plan
- [ ] Fresh install on macOS
- [ ] Enable "Save Audio Recordings" in settings  
- [ ] Start recording immediately without restarting app
- [ ] Verify audio file is saved in recordings folder

Fixes #307
