### PR TITLE
fix: improve transcription quality and add parallel resampling for la…

### DIFF
--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -133,6 +133,7 @@ bytes = { version = "1.9.0", features = ["serde"] }
 esaxx-rs = "0.1.10"
 symphonia = { version = "0.5.4", features = ["aac", "isomp4", "opt-simd"] }
 rand = "0.8.5"
+rayon = "1.10"
 rubato = "0.15.0"
 ringbuf = "0.4.8"
 

--- a/frontend/src-tauri/src/api/api.rs
+++ b/frontend/src-tauri/src/api/api.rs
@@ -12,7 +12,6 @@ use crate::{
             transcript::TranscriptsRepository,
         },
     },
-    onboarding::load_onboarding_status,
     state::AppState,
     summary::CustomOpenAIConfig,
 };
@@ -466,7 +465,7 @@ pub async fn api_update_profile<R: Runtime>(
 
 #[tauri::command]
 pub async fn api_get_model_config<R: Runtime>(
-    app: AppHandle<R>,
+    _app: AppHandle<R>,
     state: tauri::State<'_, AppState>,
     _auth_token: Option<String>,
 ) -> Result<Option<ModelConfig>, String> {

--- a/frontend/src-tauri/src/audio/devices/discovery.rs
+++ b/frontend/src-tauri/src/audio/devices/discovery.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use log::error;
 

--- a/frontend/src-tauri/src/audio/incremental_saver.rs
+++ b/frontend/src-tauri/src/audio/incremental_saver.rs
@@ -240,7 +240,7 @@ pub struct AudioRecoveryStatus {
 #[tauri::command]
 pub async fn recover_audio_from_checkpoints(
     meeting_folder: String,
-    sample_rate: u32
+    _sample_rate: u32
 ) -> Result<AudioRecoveryStatus, String> {
     info!("Starting audio recovery for folder: {}", meeting_folder);
 

--- a/frontend/src-tauri/src/audio/pipeline.rs
+++ b/frontend/src-tauri/src/audio/pipeline.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use anyhow::Result;
 use log::{debug, error, info, warn};
-use crate::{perf_debug, batch_audio_metric};
+use crate::batch_audio_metric;
 use super::batch_processor::AudioMetricsBatcher;
 use rubato::{Resampler, SincFixedIn, SincInterpolationParameters, SincInterpolationType, WindowFunction};
 

--- a/frontend/src-tauri/src/notifications/commands.rs
+++ b/frontend/src-tauri/src/notifications/commands.rs
@@ -7,7 +7,6 @@ use crate::notifications::{
 use anyhow::Result;
 use log::{info as log_info, error as log_error};
 use tauri::{State, AppHandle, Runtime, Wry};
-use tauri::Manager;
 use tauri_plugin_notification::NotificationExt;
 use std::sync::Arc;
 use tokio::sync::RwLock;

--- a/frontend/src-tauri/src/summary/summary_engine/sidecar.rs
+++ b/frontend/src-tauri/src/summary/summary_engine/sidecar.rs
@@ -480,7 +480,7 @@ impl SidecarManager {
         // Send shutdown command
         if self.is_healthy() {
             let request = serde_json::json!({"type": "shutdown"}).to_string();
-            let timeout = Duration::from_secs(5);
+            let _timeout = Duration::from_secs(5);
 
             // Try to send shutdown command, but ignore errors
             // We don't use send_request to avoid incrementing counter

--- a/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
+++ b/frontend/src-tauri/src/whisper_engine/whisper_engine.rs
@@ -10,7 +10,6 @@ use anyhow::{Result, anyhow};
 use reqwest::Client;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
-use crate::{perf_debug, perf_trace};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ModelStatus {


### PR DESCRIPTION
## Summary

Fixes poor transcription quality for large imported/retranscribed audio files (>5 min) and adds parallel chunk resampling to maintain throughput.

- **Transcription quality fix**: Replaced linear interpolation resampler with high-quality sinc resampler for the chunked path on large files. The linear resampler lacked an anti-aliasing filter, causing aliasing artifacts that made VAD miss ~99% of speech in long recordings
- **Parallel chunk resampling**: Uses `rayon` to resample 60-second audio chunks in parallel, recovering the throughput lost by the higher-quality sinc resampler. Chunks are merged sequentially with 100ms cross-fade to eliminate boundary discontinuities
- **Progress callbacks**: Added progress reporting for both decode and resample stages so the UI can display real-time progress on long files

Builds on #336

## Problem

The chunked resampling path (used for files >5 min / 14.4M samples) used simple linear interpolation which lacks an anti-aliasing filter. When downsampling from 48kHz to 16kHz (Whisper's required rate), this introduces aliasing artifacts that corrupt the signal enough for VAD to miss nearly all speech — resulting in empty or near-empty transcripts for long recordings.

## Solution

### Quality Fix
Switched `chunked_resample_with_progress()` to use the same high-quality sinc resampler (`resample()` via rubato with sinc interpolation, window size 512) already used for short files. This eliminates aliasing and restores VAD accuracy to expected levels.

### Parallel Resampling
The sinc resampler is ~3-5x slower per chunk than linear interpolation. To compensate, chunks are now resampled in parallel using `rayon::par_iter()`:

```
Input audio (e.g. 30 min at 48kHz)
    ↓
Split into 60-second chunks with 100ms overlap
    ↓
Resample all chunks in parallel (rayon)   ← CPU-bound, independent
    ↓
Merge sequentially with linear cross-fade  ← order-dependent, serial
    ↓
Output (16kHz mono for Whisper)
```

Each chunk's `resample()` call is independent and CPU-bound — ideal for data parallelism. The cross-fade merge must remain sequential since it reads the tail of the previous output.

## Files Changed

| File | Change |
|------|--------|
| `frontend/src-tauri/Cargo.toml` | Added `rayon = "1.10"` dependency |
| `frontend/src-tauri/src/audio/decoder.rs` | Parallel sinc resampling via rayon, progress callbacks, removed unused import |
| `frontend/src-tauri/src/audio/audio_processing.rs` | Added `resample()` returning `Result` for per-chunk error handling |

## Test Plan

- [ ] `cargo test -p meetily -- audio::decoder::tests` — all 15 decoder tests pass
- [ ] `cargo test -p meetily -- audio::import::tests audio::retranscription::tests audio::decoder::tests` — full suite (43 tests pass)
- [ ] Import a long audio file (>5 min) — should produce accurate transcription (not empty/sparse)
- [ ] Verify no regression in live recording transcription quality