### PR TITLE
fix: preserve model settings and Ollama endpoint across provider switches

### DIFF
--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -210,10 +210,11 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
                   endpoint: customConfig.endpoint,
                   model: customConfig.model,
                 });
+                const resolvedModel = customConfig.model || data.model || '';
                 setModelConfig(prev => ({
                   ...prev,
                   provider: data.provider,
-                  model: customConfig.model || data.model || prev.model,
+                  model: resolvedModel || prev.model,
                   whisperModel: data.whisperModel || prev.whisperModel,
                   customOpenAIEndpoint: customConfig.endpoint,
                   customOpenAIModel: customConfig.model,
@@ -222,6 +223,14 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
                   temperature: customConfig.temperature,
                   topP: customConfig.topP,
                 }));
+
+                // Seed per-provider model cache from DB
+                if (resolvedModel) {
+                  const map = JSON.parse(localStorage.getItem('providerModelMap') || '{}');
+                  map[data.provider] = resolvedModel;
+                  localStorage.setItem('providerModelMap', JSON.stringify(map));
+                }
+
                 return; // Early return
               }
             } catch (err) {
@@ -237,6 +246,13 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
             whisperModel: data.whisperModel || prev.whisperModel,
             ollamaEndpoint: data.ollamaEndpoint,
           }));
+
+          // Seed per-provider model cache from DB
+          if (data.model) {
+            const map = JSON.parse(localStorage.getItem('providerModelMap') || '{}');
+            map[data.provider] = data.model;
+            localStorage.setItem('providerModelMap', JSON.stringify(map));
+          }
         }
       } catch (error) {
         console.error('Failed to fetch saved model config in ConfigContext:', error);


### PR DESCRIPTION
## Description

Fixes multiple issues with model configuration persistence when switching between LLM providers:

1. **Ollama endpoint was hardcoded to `localhost:11434`** — Replaced the raw `fetch()` call with the Tauri `get_ollama_models` command, which uses the user's saved endpoint from config instead of a hardcoded URL.

2. **Ollama endpoint was cleared when saving with a non-Ollama provider** — The save handler now preserves `ollamaEndpoint` when the active provider is not Ollama, instead of setting it to `null`.

3. **Auto-select effect overrode saved model choice** — Removed the `useEffect` that unconditionally selected the first Ollama model whenever the model list loaded, which was overwriting the user's saved selection from the database.

4. **Model selection lost when switching providers** — Added a `providerModelMap` localStorage cache that remembers the last selected model per provider. When switching back to a provider, the previous model choice is restored. The cache is seeded from the database on initial config load.

## Issues:
- Addressed #346 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass

## Documentation
- [ ] Documentation updated
- [ ] No documentation needed

## Checklist
- [ ] Code follows project style
- [ ] Self-reviewed the code
- [ ] Added comments for complex code
- [ ] Updated README if needed
- [ ] Branch is up to date with devtest
- [ ] No merge conflicts

### Files Changed
- `frontend/src/contexts/ConfigContext.tsx` — Replaced hardcoded Ollama fetch, removed auto-select override, seeds localStorage cache from DB
- `frontend/src/components/ModelSettingsModal.tsx` — Preserves endpoint on save, caches/restores model per provider on switch and on async model list load
