### PR TITLE
Fix Linux GPU auto-detect fallback and avoid bad hipblas default

### DIFF
--- a/frontend/build-gpu.sh
+++ b/frontend/build-gpu.sh
@@ -113,8 +113,13 @@ if [ -n "$TAURI_GPU_FEATURE" ]; then
     if [ "$LLAMA_FEATURE" = "coreml" ]; then
         LLAMA_FEATURE="metal"
         echo -e "${YELLOW}   Note: llama-cpp-2 doesn't support CoreML, using Metal instead${NC}"
+  elif [ "$LLAMA_FEATURE" = "hipblas" ] || [ "$LLAMA_FEATURE" = "openblas" ]; then
+    LLAMA_FEATURE=""
+    echo -e "${YELLOW}   Note: llama-helper doesn't support '$TAURI_GPU_FEATURE', building helper in CPU mode${NC}"
     fi
+  if [ -n "$LLAMA_FEATURE" ]; then
     HELPER_FEATURES="--features $LLAMA_FEATURE"
+  fi
 fi
 
 echo -e "   Building in $HELPER_DIR with features: ${HELPER_FEATURES:-none}"

--- a/frontend/dev-gpu.sh
+++ b/frontend/dev-gpu.sh
@@ -105,8 +105,13 @@ if [ -n "$TAURI_GPU_FEATURE" ] && [ "$TAURI_GPU_FEATURE" != "none" ]; then
     if [ "$LLAMA_FEATURE" = "coreml" ]; then
         LLAMA_FEATURE="metal"
         echo -e "${YELLOW}   Note: llama-cpp-2 doesn't support CoreML, using Metal instead${NC}"
+    elif [ "$LLAMA_FEATURE" = "hipblas" ] || [ "$LLAMA_FEATURE" = "openblas" ]; then
+        LLAMA_FEATURE=""
+        echo -e "${YELLOW}   Note: llama-helper doesn't support '$TAURI_GPU_FEATURE', building helper in CPU mode${NC}"
     fi
-    HELPER_FEATURES="--features $LLAMA_FEATURE"
+    if [ -n "$LLAMA_FEATURE" ]; then
+        HELPER_FEATURES="--features $LLAMA_FEATURE"
+    fi
 fi
 
 echo -e "   Building in $HELPER_DIR with features: ${HELPER_FEATURES:-none}"

--- a/frontend/scripts/auto-detect-gpu.js
+++ b/frontend/scripts/auto-detect-gpu.js
@@ -16,6 +16,17 @@ function commandExists(cmd) {
   }
 }
 
+function getHipccMajorVersion() {
+  try {
+    const output = execSync('hipcc --version', { encoding: 'utf8' });
+    const match = output.match(/HIP version:\s*(\d+)\./i) || output.match(/HIP\s+version\s+(\d+)\./i);
+    if (!match) return null;
+    return Number.parseInt(match[1], 10);
+  } catch {
+    return null;
+  }
+}
+
 function detectGPU() {
   const platform = os.platform();
 
@@ -40,8 +51,7 @@ function detectGPU() {
         console.log('🟢 NVIDIA GPU detected with CUDA - using CUDA acceleration');
         return 'cuda';
       } else {
-        console.log('⚠️  NVIDIA GPU detected but CUDA not installed - falling back to CPU');
-        return null;
+        console.log('⚠️  NVIDIA GPU detected but CUDA not installed - checking other acceleration options');
       }
     }
 
@@ -49,8 +59,14 @@ function detectGPU() {
     if (platform === 'linux' && commandExists('rocm-smi')) {
       const rocmPath = process.env.ROCM_PATH;
       if (rocmPath || commandExists('hipcc')) {
+        const hipccMajor = getHipccMajorVersion();
+        if (hipccMajor !== null && hipccMajor >= 6) {
+          console.log(`⚠️  AMD GPU + ROCm ${hipccMajor}.x detected, but current HIPBlas backend may be incompatible - checking other acceleration options`);
+          console.log('   Tip: set TAURI_GPU_FEATURE=hipblas to force and test manually');
+        } else {
         console.log('🔴 AMD GPU detected with ROCm - using HIPBlas acceleration');
         return 'hipblas';
+        }
       } else {
         console.log('⚠️  AMD GPU detected but ROCm not installed - falling back to CPU');
         return null;


### PR DESCRIPTION
## Description
This fixes Linux GPU detection order so AMD can still be detected when NVIDIA is present without CUDA.
It also avoids passing unsupported helper features to llama-helper.
For ROCm 6+ environments, auto-detect now skips hipblas because build will fail with it.
Manual override still works via TAURI_GPU_FEATURE=hipblas for local testing.

## Related Issue
[Link to the issue this PR addresses (e.g., "Fixes #123")]

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [ ] Code follows project style
- [ ] Self-reviewed the code
- [ ] Added comments for complex code
- [ ] Updated README if needed
- [ ] Branch is up to date with devtest
- [ ] No merge conflicts

## Screenshots (if applicable)
[Add screenshots here if your changes affect the UI]

## Additional Notes
[Add any additional information that might be helpful for reviewers] 