### PR TITLE
fix: resolve remaining PR #372 review bugs

### DIFF
--- a/frontend/src-tauri/src/audio/common.rs
+++ b/frontend/src-tauri/src/audio/common.rs
@@ -161,9 +161,9 @@ pub(crate) fn split_segment_at_silence(
             confidence: segment.confidence,
         });
 
-        // Advance position: if we used overlap, start next chunk at the split point
-        // (not at chunk_end) so the overlap region is transcribed by both chunks
-        pos = split_at;
+        // Advance position to where the current chunk actually ends
+        // to avoid transcribing the overlap region twice
+        pos = chunk_end;
     }
 
     result

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -164,9 +164,11 @@ export default function RootLayout({
     const cleanedUpRef = { current: false };
 
     const setupListeners = async () => {
-      // Drag enter/over - show overlay
+      // Drag enter/over - show overlay only if beta feature is enabled
       const unlistenDragEnter = await listen('tauri://drag-enter', () => {
-        setShowDropOverlay(true);
+        if (loadBetaFeatures().importAndRetranscribe) {
+          setShowDropOverlay(true);
+        }
       });
       if (cleanedUpRef.current) {
         unlistenDragEnter();

--- a/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
+++ b/frontend/src/components/ImportAudio/ImportAudioDialog.tsx
@@ -91,6 +91,7 @@ export function ImportAudioDialog({
     setSelectedModelKey,
     loadingModels,
     fetchModels,
+    resetSelection,
   } = useTranscriptionModels(transcriptModelConfig);
 
   const handleImportComplete = useCallback((result: ImportResult) => {
@@ -133,6 +134,7 @@ export function ImportAudioDialog({
     // Only initialize when transitioning from closed (false) to open (true)
     if (open && !wasOpen) {
       reset();
+      resetSelection();
       setTitle('');
       setTitleModifiedByUser(false);
       setSelectedLang(selectedLanguage || 'auto');
@@ -150,7 +152,7 @@ export function ImportAudioDialog({
       // Fetch available models using centralized hook
       fetchModels();
     }
-  }, [open, preselectedFile, selectedLanguage, transcriptModelConfig, reset, validateFile, fetchModels]);
+  }, [open, preselectedFile, selectedLanguage, transcriptModelConfig, reset, resetSelection, validateFile, fetchModels]);
 
   // Update title when fileInfo changes
   useEffect(() => {
@@ -162,6 +164,7 @@ export function ImportAudioDialog({
   const selectedModel = useMemo((): ModelOption | undefined => {
     if (!selectedModelKey) return undefined;
     const colonIndex = selectedModelKey.indexOf(':');
+    if (colonIndex === -1) return undefined;
     const provider = selectedModelKey.slice(0, colonIndex);
     const name = selectedModelKey.slice(colonIndex + 1);
     return availableModels.find((m) => m.provider === provider && m.name === name);


### PR DESCRIPTION

## Description

Fixes 5 remaining bugs identified during the PR #372 review that were not addressed in the PR #374 fix round:

1. **Duplicate transcription text** — Overlap split in `common.rs` set `pos = split_at` instead of `pos = chunk_end`, causing 1 second of audio to be transcribed twice whenever no silence boundary was found. Produced scattered duplicate sentence fragments in long recordings.
2. **RetranscribeDialog state reset** — The `prevOpenRef` guard added to `ImportAudioDialog` in PR #374 was not ported to `RetranscribeDialog`. Config changes while the dialog was open silently reset user's language and model selections.
3. **Model selection overwrite** — `fetchModels()` in `useTranscriptionModels` unconditionally overwrote `selectedModelKey` with the configured default. Added `userSelectedRef` tracking so manual selections are preserved across re-fetches.
4. **Model key parsing truncation** — `indexOf(':')` returns -1 when no colon is present, causing `slice(0, -1)` to silently truncate the provider string. Added early return guard in both dialogs.
5. **Drop overlay when beta disabled** — `ImportDropOverlay` was visible on drag events even when the import beta feature was disabled. Now checks `loadBetaFeatures()` before showing the overlay.

## Related Issue

Follow-up to PR #372 and PR #374

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] All tests pass

**Test plan:**
- [ ] Import a long audio file (>5 min continuous speech) — verify no duplicate sentence fragments
- [ ] Open RetranscribeDialog, change model, trigger config change — verify selection preserved
- [ ] Open ImportAudioDialog, select non-default model — verify it persists through import
- [ ] Disable import beta, drag audio file over app — verify no overlay appears
- [ ] Enable import beta, drag and drop — verify overlay + import flow works

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)

N/A — no UI layout changes

## Additional Notes

| File | Change |
|------|--------|
| `frontend/src-tauri/src/audio/common.rs` | `pos = split_at` → `pos = chunk_end` |
| `frontend/src/hooks/useTranscriptionModels.ts` | `userSelectedRef` + `resetSelection()` |
| `frontend/src/components/MeetingDetails/RetranscribeDialog.tsx` | `prevOpenRef` guard, no-colon guard, `resetSelection()` |
| `frontend/src/components/ImportAudio/ImportAudioDialog.tsx` | No-colon guard, `resetSelection()` |
| `frontend/src/app/layout.tsx` | Beta gate on drag overlay |
