### PR TITLE
fix: unload transcription engine after batch jobs to free memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ Transcribe meetings entirely on your device using **Whisper** or **Parakeet** mo
     <img src="docs/home.png" width="650" style="border-radius: 10px;" alt="Meetily Demo" />
 </p>
 
+### 📥 Import & Enhance `Beta`
+
+Import existing audio files to generate transcripts, or enhance to re-transcribe any recorded meeting with a different model or language, all processed locally.
+
+<p align="center">
+    <img src="docs/import_enhance.png" width="650" style="border-radius: 10px;" alt="Import and Enhance" />
+</p>
+
 ### 🤖 AI-Powered Summaries
 
 Generate meeting summaries with your choice of AI provider. **Ollama** (local) is recommended, with support for Claude, Groq, OpenRouter, and OpenAI.

--- a/README.md
+++ b/README.md
@@ -145,8 +145,10 @@ Transcribe meetings entirely on your device using **Whisper** or **Parakeet** mo
 
 Import existing audio files to generate transcripts, or enhance to re-transcribe any recorded meeting with a different model or language, all processed locally.
 
+> Contributed by [Jeremi Joslin](https://github.com/jeremi), improved by [Vishnu P S](https://github.com/p-s-vishnu) and [Mohammed Safvan](https://github.com/mohammedsafvan)
+
 <p align="center">
-    <img src="docs/import_enhance.png" width="650" style="border-radius: 10px;" alt="Import and Enhance" />
+    <img src="docs/meetily-export.gif" width="650" style="border-radius: 10px;" alt="Import and Enhance" />
 </p>
 
 ### 🤖 AI-Powered Summaries

--- a/frontend/src-tauri/src/audio/common.rs
+++ b/frontend/src-tauri/src/audio/common.rs
@@ -4,6 +4,36 @@ use log::{debug, info};
 use std::path::Path;
 use uuid::Uuid;
 
+/// Unload the transcription engine after a batch job (import or retranscription).
+/// Skips unloading if a live recording is currently in progress, since recording
+/// uses the same global engine instances.
+pub(crate) async fn unload_engine_after_batch(use_parakeet: bool) {
+    if crate::audio::recording_commands::is_recording().await {
+        log::info!("Skipping model unload after batch: recording in progress");
+        return;
+    }
+
+    if use_parakeet {
+        use crate::parakeet_engine::commands::PARAKEET_ENGINE;
+        let engine = {
+            let guard = PARAKEET_ENGINE.lock().unwrap_or_else(|e| e.into_inner());
+            guard.as_ref().cloned()
+        };
+        if let Some(e) = engine {
+            e.unload_model().await;
+        }
+    } else {
+        use crate::whisper_engine::commands::WHISPER_ENGINE;
+        let engine = {
+            let guard = WHISPER_ENGINE.lock().unwrap_or_else(|e| e.into_inner());
+            guard.as_ref().cloned()
+        };
+        if let Some(e) = engine {
+            e.unload_model().await;
+        }
+    }
+}
+
 /// Create transcript segments from transcription results.
 /// Each tuple is (text, start_ms, end_ms) from VAD timestamps.
 pub(crate) fn create_transcript_segments(transcripts: &[(String, f64, f64)]) -> Vec<TranscriptSegment> {

--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -265,6 +265,7 @@ pub async fn start_import<R: Runtime>(
     // Reset cancellation flag
     IMPORT_CANCELLED.store(false, Ordering::SeqCst);
 
+    let use_parakeet = provider.as_deref() == Some("parakeet");
     let result = run_import(
         app.clone(),
         source_path,
@@ -274,6 +275,9 @@ pub async fn start_import<R: Runtime>(
         provider,
     )
     .await;
+
+    // Unload the engine after the batch job (success, failure, or cancellation)
+    super::common::unload_engine_after_batch(use_parakeet).await;
 
     // Guard will automatically clear flag on drop
     // No need for manual: IMPORT_IN_PROGRESS.store(false, Ordering::SeqCst);

--- a/frontend/src-tauri/src/audio/import.rs
+++ b/frontend/src-tauri/src/audio/import.rs
@@ -600,7 +600,7 @@ async fn run_import<R: Runtime>(
             debug!(
                 "Segment {}/{}: {:.1}s, conf={:.2}, text='{}'",
                 i + 1, processable_count, segment_duration_sec, conf,
-                if trimmed.len() > 80 { &trimmed[..trimmed.floor_char_boundary(80)] } else { trimmed }
+                if trimmed.len() > 80 { let mut end = 80; while !trimmed.is_char_boundary(end) { end -= 1; } &trimmed[..end] } else { trimmed }
             );
             all_transcripts.push((text, segment.start_timestamp_ms, segment.end_timestamp_ms));
             total_confidence += conf;

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -390,7 +390,7 @@ async fn run_retranscription<R: Runtime>(
             debug!(
                 "Segment {}/{}: {:.1}s, conf={:.2}, text='{}'",
                 i + 1, processable_count, segment_duration_sec, conf,
-                if trimmed.len() > 80 { &trimmed[..trimmed.floor_char_boundary(80)] } else { trimmed }
+                if trimmed.len() > 80 { let mut end = 80; while !trimmed.is_char_boundary(end) { end -= 1; } &trimmed[..end] } else { trimmed }
             );
             all_transcripts.push((text, segment.start_timestamp_ms, segment.end_timestamp_ms));
             total_confidence += conf;

--- a/frontend/src-tauri/src/audio/retranscription.rs
+++ b/frontend/src-tauri/src/audio/retranscription.rs
@@ -101,7 +101,11 @@ pub async fn start_retranscription<R: Runtime>(
     // Reset cancellation flag
     RETRANSCRIPTION_CANCELLED.store(false, Ordering::SeqCst);
 
+    let use_parakeet = provider.as_deref() == Some("parakeet");
     let result = run_retranscription(app.clone(), meeting_id.clone(), meeting_folder_path, language, model, provider).await;
+
+    // Unload the engine after the batch job (success, failure, or cancellation)
+    super::common::unload_engine_after_batch(use_parakeet).await;
 
     // Guard will automatically clear flag on drop
     // No need for manual: RETRANSCRIPTION_IN_PROGRESS.store(false, Ordering::SeqCst);


### PR DESCRIPTION
## Description
- Add shared `unload_engine_after_batch(use_parakeet)` in common.rs
- Skips unload if a live recording is in progress (guards shared engine)
- Call after import completion (success, failure, or cancellation)
- Call after retranscription completion (success, failure, or cancellation)

## Related Issue

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe)

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] All tests pass

## Documentation
- [ ] Documentation updated
- [ ] No documentation needed

## Checklist
- [ ] Code follows project style
- [ ] Self-reviewed the code
- [ ] Added comments for complex code
- [ ] Updated README if needed
- [ ] Branch is up to date with devtest
- [ ] No merge conflicts

## Screenshots (if applicable)
[Add screenshots here if your changes affect the UI]

## Additional Notes
[Add any additional information that might be helpful for reviewers] 