### PR TITLE
feat: add build info to About page

### DIFF
--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -64,6 +64,48 @@ use tokio::sync::RwLock;
 
 static RECORDING_FLAG: AtomicBool = AtomicBool::new(false);
 
+#[derive(Debug, Serialize, Clone)]
+pub struct BuildInfo {
+    pub version: String,
+    pub gpu_backend: String,
+    pub build_profile: String,
+    pub target_os: String,
+    pub target_arch: String,
+}
+
+#[tauri::command]
+fn get_build_info() -> BuildInfo {
+    let gpu_backend = if cfg!(feature = "cuda") {
+        "CUDA"
+    } else if cfg!(feature = "vulkan") {
+        "Vulkan"
+    } else if cfg!(feature = "metal") {
+        "Metal"
+    } else if cfg!(feature = "coreml") {
+        "CoreML"
+    } else if cfg!(feature = "hipblas") {
+        "HipBLAS (AMD ROCm)"
+    } else if cfg!(feature = "openblas") {
+        "OpenBLAS (CPU)"
+    } else {
+        "CPU"
+    };
+
+    let build_profile = if cfg!(debug_assertions) {
+        "Debug"
+    } else {
+        "Release"
+    };
+
+    BuildInfo {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        gpu_backend: gpu_backend.to_string(),
+        build_profile: build_profile.to_string(),
+        target_os: std::env::consts::OS.to_string(),
+        target_arch: std::env::consts::ARCH.to_string(),
+    }
+}
+
 // Global language preference storage (default to "auto-translate" for automatic translation to English)
 static LANGUAGE_PREFERENCE: std::sync::LazyLock<StdMutex<String>> =
     std::sync::LazyLock::new(|| StdMutex::new("auto-translate".to_string()));
@@ -716,6 +758,7 @@ pub fn run() {
             audio::import::start_import_audio_command,
             audio::import::cancel_import_command,
             audio::import::is_import_in_progress_command,
+            get_build_info,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/frontend/src/components/About.tsx
+++ b/frontend/src/components/About.tsx
@@ -6,8 +6,16 @@ import AnalyticsConsentSwitch from "./AnalyticsConsentSwitch";
 import { UpdateDialog } from "./UpdateDialog";
 import { updateService, UpdateInfo } from '@/services/updateService';
 import { Button } from './ui/button';
-import { Loader2, CheckCircle2 } from 'lucide-react';
+import { Loader2, CheckCircle2, Monitor } from 'lucide-react';
 import { toast } from 'sonner';
+
+interface BuildInfo {
+    version: string;
+    gpu_backend: string;
+    build_profile: string;
+    target_os: string;
+    target_arch: string;
+}
 
 
 export function About() {
@@ -15,10 +23,11 @@ export function About() {
     const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
     const [isChecking, setIsChecking] = useState(false);
     const [showUpdateDialog, setShowUpdateDialog] = useState(false);
+    const [buildInfo, setBuildInfo] = useState<BuildInfo | null>(null);
 
     useEffect(() => {
-        // Get current version on mount
         getVersion().then(setCurrentVersion).catch(console.error);
+        invoke<BuildInfo>('get_build_info').then(setBuildInfo).catch(console.error);
     }, []);
 
     const handleContactClick = async () => {
@@ -144,6 +153,24 @@ export function About() {
                 </p>
             </div>
             <AnalyticsConsentSwitch />
+
+            {/* Build Info */}
+            {buildInfo && (
+                <div className="bg-gray-50 rounded p-3 space-y-1.5">
+                    <div className="flex items-center gap-1.5 text-sm font-semibold text-gray-800">
+                        <Monitor className="h-3.5 w-3.5" />
+                        Build Info
+                    </div>
+                    <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-gray-600">
+                        <span className="text-gray-500">GPU Backend</span>
+                        <span className="font-medium">{buildInfo.gpu_backend}</span>
+                        <span className="text-gray-500">Build Profile</span>
+                        <span className="font-medium">{buildInfo.build_profile}</span>
+                        <span className="text-gray-500">Platform</span>
+                        <span className="font-medium">{buildInfo.target_os}/{buildInfo.target_arch}</span>
+                    </div>
+                </div>
+            )}
 
             {/* Update Dialog */}
             <UpdateDialog


### PR DESCRIPTION
## Summary
- Adds a `get_build_info` Tauri command exposing compile-time GPU backend, build profile, and platform info
- Displays build info section in the About page below the Analytics section
- Supports CUDA, Vulkan, Metal, CoreML, HipBLAS, OpenBLAS, and CPU-only detection

## Test plan
- [ ] Open Settings > About and verify build info section is visible
- [ ] Verify GPU Backend shows correct value for the build (e.g., CUDA, Vulkan, CPU)
- [ ] Verify Platform shows correct OS/arch

🤖 Generated with [Claude Code](https://claude.com/claude-code)