### PR TITLE
ci: add workflow to auto-update homebrew tap on release

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -1,0 +1,76 @@
+name: Update Homebrew Tap
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-tap:
+    name: Bump meetily cask to ${{ github.event.release.tag_name }}
+    runs-on: ubuntu-latest
+    if: >-
+      !github.event.release.prerelease &&
+      !github.event.release.draft
+
+    steps:
+      - name: Parse version
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}"         >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Download macOS DMG and compute SHA256
+        id: artifact
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
+          DMG_NAME="meetily_${VERSION}_aarch64.dmg"
+          DMG_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/${DMG_NAME}"
+
+          echo "Downloading: ${DMG_URL}"
+          curl -fsSL --retry 3 -o meetily.dmg "${DMG_URL}"
+
+          SHA256=$(sha256sum meetily.dmg | awk '{print $1}')
+          echo "sha256=${SHA256}"     >> "$GITHUB_OUTPUT"
+          echo "url=${DMG_URL}"       >> "$GITHUB_OUTPUT"
+          echo "dmg_name=${DMG_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: vedansh-agarwal/homebrew-meetily
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update version and sha256 in cask
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA256:  ${{ steps.artifact.outputs.sha256 }}
+        run: |
+          sed -i "s/^\(  version \"\)[^\"]*\"/\1${VERSION}\"/" homebrew-tap/Casks/meetily.rb
+          sed -i "s/^\(  sha256 \"\)[^\"]*\"/\1${SHA256}\"/" homebrew-tap/Casks/meetily.rb
+
+          echo "--- Updated cask ---"
+          cat homebrew-tap/Casks/meetily.rb
+
+      - name: Commit and push to tap
+        run: |
+          cd homebrew-tap
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add Casks/meetily.rb
+
+          if git diff --cached --quiet; then
+            echo "No changes — cask is already at ${{ steps.version.outputs.version }}"
+            exit 0
+          fi
+
+          git commit -m "chore: bump meetily to ${{ steps.version.outputs.version }}
+
+          Auto-updated by the release workflow in
+          https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.tag }}"
+
+          git push

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout homebrew tap
         uses: actions/checkout@v4
         with:
-          repository: vedansh-agarwal/homebrew-meetily
+          repository: Zackriya-Solutions/homebrew-meetily
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 


### PR DESCRIPTION
## Description
Adds a GitHub Actions workflow that automatically updates the Homebrew tap
(`Zackriya-Solutions/homebrew-meetily`) whenever a new release is published.

On each non-draft, non-prerelease `release: published` event, the workflow:
1. Downloads the `_aarch64.dmg` asset
2. Computes its SHA256
3. Checks out the tap repo and updates the `version` and `sha256` fields in `Casks/meetily.rb` using `sed`
4. Commits and pushes the bump with an attribution link back to the triggering release

This eliminates the manual step of updating the tap after each release.

## Related Issue
N/A — this is a self-contained automation improvement.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Other (CI/CD automation — new workflow file only, no source code changes)

## Testing
- [x] Manual testing performed
- [x] All tests pass

Tested end-to-end on a fork (`vedansh-agarwal/meetily` → `vedansh-agarwal/homebrew-meetily`):
created a test release with a renamed DMG asset, confirmed the workflow ran successfully and
committed the correct version and SHA256 to the tap.

## Documentation
- [ ] Documentation updated
- [x] No documentation needed

The workflow file is self-documenting.

## Checklist
- [x] Code follows project style
- [x] Self-reviewed the code
- [x] Added comments for complex code
- [ ] Updated README if needed
- [x] Branch is up to date with devtest
- [x] No merge conflicts

## Screenshots (if applicable)
N/A — workflow file addition only.

## Additional Notes
**One manual step required by the repo maintainer:** a fine-grained PAT named
`HOMEBREW_TAP_TOKEN` must be added to this repo's secrets with **Contents: Read and Write**
permission scoped to `Zackriya-Solutions/homebrew-meetily`. Without it the workflow will
fail at the push step.

This PR is a companion to a separate PR on the tap repo itself
(`Zackriya-Solutions/homebrew-meetily`) which updates the cask to v0.3.0 and cleans up
the obsolete backend formula.